### PR TITLE
[Feat] 상품 고유 번호 필터링

### DIFF
--- a/src/main/java/com/umc/EveryWear/domain/product/controller/ProductController.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/controller/ProductController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Product", description = "상품 관련 API")
 @RestController
-@RequestMapping("/api/product")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class ProductController {
 
@@ -33,12 +33,12 @@ public class ProductController {
                     " • 앱 공유하기: https://musinsa.onelink.me/ANAQ/{공유코드}\n\n" +
                     " • 쇼핑몰 앱 공유하기: https://musinsa.onelink.me/PvkC/{공유코드}"
     )
-    @PostMapping("/import/musinsa")
+    @PostMapping("/product/import/musinsa")
     public ApiResponse<ProductResDTO.ImportDTO> importMusinsaProduct(
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody ProductReqDTO.ImportMusinsaDTO dto
     ) {
-        ProductResDTO.ImportDTO response = productCommandService.importMusinsaProduct(dto);
+        ProductResDTO.ImportDTO response = productCommandService.importMusinsaProduct(userId, dto);
         ProductSuccessCode successCode;
         if (response.getIsUrlUpdated() != null && response.getIsUrlUpdated()) {
             successCode = ProductSuccessCode.MUSINSA_PRODUCT_URL_UPDATED;
@@ -60,12 +60,12 @@ public class ProductController {
                     " • 앱 공유하기: https://zigzag.kr/catalog/products/{상품ID}\n\n" +
                     " • 쇼핑몰 앱 공유하기: https://s.zigzag.kr/{공유코드}"
     )
-    @PostMapping("/import/zigzag")
+    @PostMapping("/product/import/zigzag")
     public ApiResponse<ProductResDTO.ImportDTO> importZigzagProduct(
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody ProductReqDTO.ImportZigzagDTO dto
     ) {
-        ProductResDTO.ImportDTO response = productCommandService.importZigzagProduct(dto);
+        ProductResDTO.ImportDTO response = productCommandService.importZigzagProduct(userId, dto);
         ProductSuccessCode successCode;
         if (response.getIsUrlUpdated() != null && response.getIsUrlUpdated()) {
             successCode = ProductSuccessCode.ZIGZAG_PRODUCT_URL_UPDATED;
@@ -87,12 +87,12 @@ public class ProductController {
                     " • 앱 공유하기: https://m.wconcept.co.kr/Product/{상품ID}?applanding=Z}\n\n" +
                     " • 쇼핑몰 앱 공유하기: https://m.wconcept.co.kr/Product/{상품ID}?applanding=Y"
     )
-    @PostMapping("/import/wconcept")
+    @PostMapping("/product/import/wconcept")
     public ApiResponse<ProductResDTO.ImportDTO> importWconceptProduct(
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody ProductReqDTO.WconceptImportDTO dto
     ) {
-        ProductResDTO.ImportDTO response = productCommandService.importWconceptProduct(dto);
+        ProductResDTO.ImportDTO response = productCommandService.importWconceptProduct(userId, dto);
         ProductSuccessCode successCode;
         if (response.getIsUrlUpdated() != null && response.getIsUrlUpdated()) {
             successCode = ProductSuccessCode.WCONCEPT_PRODUCT_URL_UPDATED;
@@ -114,12 +114,12 @@ public class ProductController {
             " • 앱 공유하기: https://29cm.onelink.me/1080201211/{공유코드}\n\n" +
             " • 쇼핑몰 앱 공유하기: https://29cm.onelink.me/1080201211/{공유코드}"
     )
-    @PostMapping("/import/29cm")
+    @PostMapping("/product/import/29cm")
     public ApiResponse<ProductResDTO.ImportDTO> import29cmProduct(
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody ProductReqDTO.Import29cmDTO dto
     ) {
-        ProductResDTO.ImportDTO response = productCommandService.import29cmProduct(dto);
+        ProductResDTO.ImportDTO response = productCommandService.import29cmProduct(userId, dto);
         ProductSuccessCode successCode;
         if (response.getIsUrlUpdated() != null && response.getIsUrlUpdated()) {
             successCode = ProductSuccessCode.CM29_PRODUCT_URL_UPDATED;

--- a/src/main/java/com/umc/EveryWear/domain/product/converter/ProductConverter.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/converter/ProductConverter.java
@@ -28,6 +28,7 @@ public class ProductConverter {
                 .price(product.getPrice())
                 .star_point(product.getStarPoint())
                 .AI_review(product.getAiReview())
+                .product_num(product.getProductNum())
                 .isUpdated(isUpdated)
                 .isUrlUpdated(isUrlUpdated)
                 .build();

--- a/src/main/java/com/umc/EveryWear/domain/product/dto/res/ProductResDTO.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/dto/res/ProductResDTO.java
@@ -19,6 +19,7 @@ public class ProductResDTO {
         private String price;
         private Float star_point;
         private String AI_review;
+        private String product_num;
 
         // 업데이트 여부 및 URL 업데이트 여부는 응답 포함X
         @JsonIgnore

--- a/src/main/java/com/umc/EveryWear/domain/product/dto/res/ProductResDTO.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/dto/res/ProductResDTO.java
@@ -19,7 +19,7 @@ public class ProductResDTO {
         private String price;
         private Float star_point;
         private String AI_review;
-        private String product_num;
+        private Long product_num;
 
         // 업데이트 여부 및 URL 업데이트 여부는 응답 포함X
         @JsonIgnore

--- a/src/main/java/com/umc/EveryWear/domain/product/entity/Product.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/entity/Product.java
@@ -43,4 +43,7 @@ public class Product extends BaseEntity {
 
     @Column(name = "AI_review", columnDefinition = "TEXT")
     private String aiReview;
+
+    @Column(name = "product_num")
+    private String productNum;
 }

--- a/src/main/java/com/umc/EveryWear/domain/product/entity/Product.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/entity/Product.java
@@ -45,5 +45,5 @@ public class Product extends BaseEntity {
     private String aiReview;
 
     @Column(name = "product_num")
-    private String productNum;
+    private Long productNum;
 }

--- a/src/main/java/com/umc/EveryWear/domain/product/entity/Product.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/entity/Product.java
@@ -1,5 +1,6 @@
 package com.umc.EveryWear.domain.product.entity;
 
+import com.umc.EveryWear.domain.user.entity.User;
 import com.umc.EveryWear.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -46,4 +47,8 @@ public class Product extends BaseEntity {
 
     @Column(name = "product_num")
     private Long productNum;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 }

--- a/src/main/java/com/umc/EveryWear/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/repository/ProductRepository.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 public interface ProductRepository extends JpaRepository<Product, Long> {
     Optional<Product> findByProductUrl(String productUrl);
     Optional<Product> findByProductNum(Long productNum);
+    Optional<Product> findByProductUrlAndUser_UserId(String productUrl, Long userId);
+    Optional<Product> findByProductNumAndUser_UserId(Long productNum, Long userId);
     
     // updatedAt 내림차순으로 모든 상품 조회
     List<Product> findAllByOrderByUpdatedAtDesc();

--- a/src/main/java/com/umc/EveryWear/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/repository/ProductRepository.java
@@ -13,18 +13,18 @@ import java.util.Optional;
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
     Optional<Product> findByProductUrl(String productUrl);
-    Optional<Product> findByProductName(String productName);
+    Optional<Product> findByProductNum(Long productNum);
     
     // updatedAt 내림차순으로 모든 상품 조회
     List<Product> findAllByOrderByUpdatedAtDesc();
     
     // updatedAt을 현재 시간으로 업데이트
     @Modifying
-    @Query("UPDATE Product p SET p.updatedAt = CURRENT_TIMESTAMP WHERE p.productId = :productId")
-    void updateUpdatedAt(@Param("productId") Long productId);
+    @Query("UPDATE Product p SET p.updatedAt = :updatedAt WHERE p.productId = :productId")
+    void updateUpdatedAt(@Param("productId") Long productId, @Param("updatedAt") java.time.LocalDateTime updatedAt);
     
     // 상품 URL과 updatedAt을 업데이트
     @Modifying
-    @Query("UPDATE Product p SET p.productUrl = :productUrl, p.updatedAt = CURRENT_TIMESTAMP WHERE p.productId = :productId")
-    void updateProductUrlAndUpdatedAt(@Param("productId") Long productId, @Param("productUrl") String productUrl);
+    @Query("UPDATE Product p SET p.productUrl = :productUrl, p.updatedAt = :updatedAt WHERE p.productId = :productId")
+    void updateProductUrlAndUpdatedAt(@Param("productId") Long productId, @Param("productUrl") String productUrl, @Param("updatedAt") java.time.LocalDateTime updatedAt);
 }

--- a/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandService.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandService.java
@@ -4,8 +4,8 @@ import com.umc.EveryWear.domain.product.dto.req.ProductReqDTO;
 import com.umc.EveryWear.domain.product.dto.res.ProductResDTO;
 
 public interface ProductCommandService {
-    ProductResDTO.ImportDTO importMusinsaProduct(ProductReqDTO.ImportMusinsaDTO dto);
-    ProductResDTO.ImportDTO importZigzagProduct(ProductReqDTO.ImportZigzagDTO dto);
-    ProductResDTO.ImportDTO importWconceptProduct(ProductReqDTO.WconceptImportDTO dto);
-    ProductResDTO.ImportDTO import29cmProduct(ProductReqDTO.Import29cmDTO dto);
+    ProductResDTO.ImportDTO importMusinsaProduct(Long userId, ProductReqDTO.ImportMusinsaDTO dto);
+    ProductResDTO.ImportDTO importZigzagProduct(Long userId, ProductReqDTO.ImportZigzagDTO dto);
+    ProductResDTO.ImportDTO importWconceptProduct(Long userId, ProductReqDTO.WconceptImportDTO dto);
+    ProductResDTO.ImportDTO import29cmProduct(Long userId, ProductReqDTO.Import29cmDTO dto);
 }

--- a/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
@@ -9,6 +9,8 @@ import com.umc.EveryWear.domain.product.entity.Product;
 import com.umc.EveryWear.domain.product.exception.ProductException;
 import com.umc.EveryWear.domain.product.exception.code.ProductErrorCode;
 import com.umc.EveryWear.domain.product.repository.ProductRepository;
+import com.umc.EveryWear.domain.user.entity.User;
+import com.umc.EveryWear.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +35,7 @@ import java.util.Map;
 public class ProductCommandServiceImpl implements ProductCommandService {
 
     private final ProductRepository productRepository;
+    private final UserRepository userRepository;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final WebClient webClient;
     
@@ -40,8 +43,12 @@ public class ProductCommandServiceImpl implements ProductCommandService {
     private String fastApiBaseUrl;
 
     @Override
-    public ProductResDTO.ImportDTO importMusinsaProduct(ProductReqDTO.ImportMusinsaDTO dto) {
+    public ProductResDTO.ImportDTO importMusinsaProduct(Long userId, ProductReqDTO.ImportMusinsaDTO dto) {
         try {
+            // User 조회
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new ProductException(ProductErrorCode.CRAWLING_FAILED));
+            
             // 2차 URL 형식 검증(이중 보호 처리)
             String productUrl = dto.getProduct_url();
             boolean isValidUrl = productUrl != null && (
@@ -52,8 +59,8 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                 throw new ProductException(ProductErrorCode.INVALID_URL_FORMAT);
             }
             
-            // URL로 이미 등록된 상품인지 확인 -> 그러면 크롤링X
-            Product existingProductByUrl = productRepository.findByProductUrl(productUrl)
+            // URL로 이미 등록된 상품인지 확인 (해당 유저의 상품만)
+            Product existingProductByUrl = productRepository.findByProductUrlAndUser_UserId(productUrl, userId)
                     .orElse(null);
             
             if (existingProductByUrl != null) {
@@ -68,10 +75,10 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             // 크롤링 실행
             ProductCrawlingData crawlerData = crawlMusinsaProduct(dto.getProduct_url());
 
-            // 크롤링 후 상품 고유값으로 이미 등록된 상품인지 확인
+            // 크롤링 후 상품 고유값으로 이미 등록된 상품인지 확인 (해당 유저의 상품만)
             Product existingProductByNum = null;
             if (crawlerData.getProductNum() != null) {
-                existingProductByNum = productRepository.findByProductNum(crawlerData.getProductNum())
+                existingProductByNum = productRepository.findByProductNumAndUser_UserId(crawlerData.getProductNum(), userId)
                         .orElse(null);
             }
             
@@ -96,6 +103,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                     .starPoint(crawlerData.getStarPoint())
                     .aiReview(crawlerData.getAiReview())
                     .productNum(crawlerData.getProductNum())
+                    .user(user)
                     .build();
 
             Product savedProduct = productRepository.save(product);
@@ -198,8 +206,12 @@ public class ProductCommandServiceImpl implements ProductCommandService {
     }
 
     @Override
-    public ProductResDTO.ImportDTO importZigzagProduct(ProductReqDTO.ImportZigzagDTO dto) {
+    public ProductResDTO.ImportDTO importZigzagProduct(Long userId, ProductReqDTO.ImportZigzagDTO dto) {
         try {
+            // User 조회
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new ProductException(ProductErrorCode.CRAWLING_FAILED));
+            
             // 2차 URL 형식 검증(이중 보호 처리)
             String productUrl = dto.getProduct_url();
             boolean isValidUrl = productUrl != null && (
@@ -210,8 +222,8 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                 throw new ProductException(ProductErrorCode.INVALID_URL_FORMAT);
             }
             
-            // URL로 이미 등록된 상품인지 확인 -> 그러면 크롤링X
-            Product existingProductByUrl = productRepository.findByProductUrl(productUrl)
+            // URL로 이미 등록된 상품인지 확인 (해당 유저의 상품만)
+            Product existingProductByUrl = productRepository.findByProductUrlAndUser_UserId(productUrl, userId)
                     .orElse(null);
             
             if (existingProductByUrl != null) {
@@ -226,10 +238,10 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             // 크롤링 실행
             ProductCrawlingData crawlerData = crawlZigzagProduct(dto.getProduct_url());
 
-            // 크롤링 후 상품 고윳값으로 이미 등록된 상품인지 확인
+            // 크롤링 후 상품 고윳값으로 이미 등록된 상품인지 확인 (해당 유저의 상품만)
             Product existingProductByNum = null;
             if (crawlerData.getProductNum() != null) {
-                existingProductByNum = productRepository.findByProductNum(crawlerData.getProductNum())
+                existingProductByNum = productRepository.findByProductNumAndUser_UserId(crawlerData.getProductNum(), userId)
                         .orElse(null);
             }
             
@@ -254,6 +266,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                     .starPoint(crawlerData.getStarPoint())
                     .aiReview(crawlerData.getAiReview())
                     .productNum(crawlerData.getProductNum())
+                    .user(user)
                     .build();
 
             Product savedProduct = productRepository.save(product);
@@ -362,8 +375,12 @@ public class ProductCommandServiceImpl implements ProductCommandService {
   
   
     @Override
-    public ProductResDTO.ImportDTO import29cmProduct(ProductReqDTO.Import29cmDTO dto) {
+    public ProductResDTO.ImportDTO import29cmProduct(Long userId, ProductReqDTO.Import29cmDTO dto) {
         try {
+            // User 조회
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new ProductException(ProductErrorCode.CRAWLING_FAILED));
+            
             // 2차 URL 형식 검증(이중 보호 처리)
             String productUrl = dto.getProduct_url();
             boolean isValidUrl = productUrl != null && (
@@ -374,8 +391,8 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                 throw new ProductException(ProductErrorCode.INVALID_URL_FORMAT);
             }
             
-            // URL로 이미 등록된 상품인지 확인 -> 그러면 크롤링X
-            Product existingProductByUrl = productRepository.findByProductUrl(productUrl)
+            // URL로 이미 등록된 상품인지 확인 (해당 유저의 상품만)
+            Product existingProductByUrl = productRepository.findByProductUrlAndUser_UserId(productUrl, userId)
                     .orElse(null);
             
             if (existingProductByUrl != null) {
@@ -390,10 +407,10 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             // 크롤링 실행
             ProductCrawlingData crawlerData = crawl29cmProduct(dto.getProduct_url());
 
-            // 크롤링 후 상품 고윳값으로 이미 등록된 상품인지 확인
+            // 크롤링 후 상품 고윳값으로 이미 등록된 상품인지 확인 (해당 유저의 상품만)
             Product existingProductByNum = null;
             if (crawlerData.getProductNum() != null) {
-                existingProductByNum = productRepository.findByProductNum(crawlerData.getProductNum())
+                existingProductByNum = productRepository.findByProductNumAndUser_UserId(crawlerData.getProductNum(), userId)
                         .orElse(null);
             }
             
@@ -418,6 +435,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                     .starPoint(crawlerData.getStarPoint())
                     .aiReview(crawlerData.getAiReview())
                     .productNum(crawlerData.getProductNum())
+                    .user(user)
                     .build();
 
             Product savedProduct = productRepository.save(product);
@@ -521,8 +539,12 @@ public class ProductCommandServiceImpl implements ProductCommandService {
 
 
     @Override
-    public ProductResDTO.ImportDTO importWconceptProduct(ProductReqDTO.WconceptImportDTO dto) {
+    public ProductResDTO.ImportDTO importWconceptProduct(Long userId, ProductReqDTO.WconceptImportDTO dto) {
         try {
+            // User 조회
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new ProductException(ProductErrorCode.CRAWLING_FAILED));
+            
             // 2차 URL 형식 검증(이중 보호 처리)
             String productUrl = dto.getProduct_url();
             boolean isValidUrl = productUrl != null && (
@@ -533,8 +555,8 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                 throw new ProductException(ProductErrorCode.INVALID_URL_FORMAT);
             }
             
-            // URL로 이미 등록된 상품인지 확인 -> 그러면 크롤링X
-            Product existingProductByUrl = productRepository.findByProductUrl(productUrl)
+            // URL로 이미 등록된 상품인지 확인 (해당 유저의 상품만)
+            Product existingProductByUrl = productRepository.findByProductUrlAndUser_UserId(productUrl, userId)
                     .orElse(null);
             
             if (existingProductByUrl != null) {
@@ -549,10 +571,10 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             // 크롤링 실행
             ProductCrawlingData crawlerData = crawlWconceptProduct(dto.getProduct_url());
 
-            // 크롤링 후 상품 고윳값으로 이미 등록된 상품인지 확인
+            // 크롤링 후 상품 고윳값으로 이미 등록된 상품인지 확인 (해당 유저의 상품만)
             Product existingProductByNum = null;
             if (crawlerData.getProductNum() != null) {
-                existingProductByNum = productRepository.findByProductNum(crawlerData.getProductNum())
+                existingProductByNum = productRepository.findByProductNumAndUser_UserId(crawlerData.getProductNum(), userId)
                         .orElse(null);
             }
             
@@ -577,6 +599,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                     .starPoint(crawlerData.getStarPoint())
                     .aiReview(crawlerData.getAiReview())
                     .productNum(crawlerData.getProductNum())
+                    .user(user)
                     .build();
 
             Product savedProduct = productRepository.save(product);

--- a/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
@@ -229,6 +229,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                     .price(crawlerData.getPrice())
                     .starPoint(crawlerData.getStarPoint())
                     .aiReview(crawlerData.getAiReview())
+                    .productNum(crawlerData.getProductNum())
                     .build();
 
             Product savedProduct = productRepository.save(product);
@@ -304,6 +305,24 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             
             data.setAiReview(jsonNode.has("AI_review") && !jsonNode.get("AI_review").isNull() ? 
                     jsonNode.get("AI_review").asText() : null);
+            
+            // product_num 처리
+            if (jsonNode.has("product_num") && !jsonNode.get("product_num").isNull()) {
+                JsonNode productNumNode = jsonNode.get("product_num");
+                if (productNumNode.isNumber()) {
+                    data.setProductNum(productNumNode.asLong());
+                } else if (productNumNode.isTextual()) {
+                    try {
+                        data.setProductNum(Long.parseLong(productNumNode.asText()));
+                    } catch (NumberFormatException e) {
+                        data.setProductNum(null);
+                    }
+                } else {
+                    data.setProductNum(null);
+                }
+            } else {
+                data.setProductNum(null);
+            }
             
             return data;
             

--- a/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
@@ -22,6 +22,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -57,7 +58,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             
             if (existingProductByUrl != null) {
                 // 기존 상품이 있으면 updatedAt을 현재 시간으로 업데이트
-                productRepository.updateUpdatedAt(existingProductByUrl.getProductId());
+                productRepository.updateUpdatedAt(existingProductByUrl.getProductId(), LocalDateTime.now());
                 // 업데이트 후 다시 조회하여 최신 정보 반환
                 Product updatedProduct = productRepository.findById(existingProductByUrl.getProductId())
                         .orElse(existingProductByUrl);
@@ -67,16 +68,19 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             // 크롤링 실행
             ProductCrawlingData crawlerData = crawlMusinsaProduct(dto.getProduct_url());
 
-            // 크롤링 후 상품명으로 이미 등록된 상품인지 확인
-            Product existingProductByName = productRepository.findByProductName(crawlerData.getProductName())
-                    .orElse(null);
+            // 크롤링 후 상품 고유값으로 이미 등록된 상품인지 확인
+            Product existingProductByNum = null;
+            if (crawlerData.getProductNum() != null) {
+                existingProductByNum = productRepository.findByProductNum(crawlerData.getProductNum())
+                        .orElse(null);
+            }
             
-            if (existingProductByName != null) {
-                // 상품명으로 이미 등록된 상품이 있으면 상품URL을 현재 URL로 업데이트하고 updatedAt 갱신
-                productRepository.updateProductUrlAndUpdatedAt(existingProductByName.getProductId(), productUrl);
+            if (existingProductByNum != null) {
+                // 상품 고윳값으로 이미 등록된 상품이 있으면 상품URL을 현재 URL로 업데이트하고 updatedAt 갱신
+                productRepository.updateProductUrlAndUpdatedAt(existingProductByNum.getProductId(), productUrl, LocalDateTime.now());
                 // 업데이트 후 다시 조회하여 최신 정보 반환
-                Product updatedProduct = productRepository.findById(existingProductByName.getProductId())
-                        .orElse(existingProductByName);
+                Product updatedProduct = productRepository.findById(existingProductByNum.getProductId())
+                        .orElse(existingProductByNum);
                 return ProductConverter.toImportDTO(updatedProduct, true, true);
             }
 
@@ -212,7 +216,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             
             if (existingProductByUrl != null) {
                 // 기존 상품이 있으면 updatedAt을 현재 시간으로 업데이트
-                productRepository.updateUpdatedAt(existingProductByUrl.getProductId());
+                productRepository.updateUpdatedAt(existingProductByUrl.getProductId(), LocalDateTime.now());
                 // 업데이트 후 다시 조회하여 최신 정보 반환
                 Product updatedProduct = productRepository.findById(existingProductByUrl.getProductId())
                         .orElse(existingProductByUrl);
@@ -222,16 +226,19 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             // 크롤링 실행
             ProductCrawlingData crawlerData = crawlZigzagProduct(dto.getProduct_url());
 
-            // 크롤링 후 상품명으로 이미 등록된 상품인지 확인
-            Product existingProductByName = productRepository.findByProductName(crawlerData.getProductName())
-                    .orElse(null);
+            // 크롤링 후 상품 고윳값으로 이미 등록된 상품인지 확인
+            Product existingProductByNum = null;
+            if (crawlerData.getProductNum() != null) {
+                existingProductByNum = productRepository.findByProductNum(crawlerData.getProductNum())
+                        .orElse(null);
+            }
             
-            if (existingProductByName != null) {
-                // 상품명으로 이미 등록된 상품이 있으면 상품URL을 현재 URL로 업데이트하고 updatedAt 갱신
-                productRepository.updateProductUrlAndUpdatedAt(existingProductByName.getProductId(), productUrl);
+            if (existingProductByNum != null) {
+                // 상품 고윳값으로 이미 등록된 상품이 있으면 상품URL을 현재 URL로 업데이트하고 updatedAt 갱신
+                productRepository.updateProductUrlAndUpdatedAt(existingProductByNum.getProductId(), productUrl, LocalDateTime.now());
                 // 업데이트 후 다시 조회하여 최신 정보 반환
-                Product updatedProduct = productRepository.findById(existingProductByName.getProductId())
-                        .orElse(existingProductByName);
+                Product updatedProduct = productRepository.findById(existingProductByNum.getProductId())
+                        .orElse(existingProductByNum);
                 return ProductConverter.toImportDTO(updatedProduct, true, true);
             }
 
@@ -373,7 +380,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             
             if (existingProductByUrl != null) {
                 // 기존 상품이 있으면 updatedAt을 현재 시간으로 업데이트
-                productRepository.updateUpdatedAt(existingProductByUrl.getProductId());
+                productRepository.updateUpdatedAt(existingProductByUrl.getProductId(), LocalDateTime.now());
                 // 업데이트 후 다시 조회하여 최신 정보 반환
                 Product updatedProduct = productRepository.findById(existingProductByUrl.getProductId())
                         .orElse(existingProductByUrl);
@@ -383,16 +390,19 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             // 크롤링 실행
             ProductCrawlingData crawlerData = crawl29cmProduct(dto.getProduct_url());
 
-            // 크롤링 후 상품명으로 이미 등록된 상품인지 확인
-            Product existingProductByName = productRepository.findByProductName(crawlerData.getProductName())
-                    .orElse(null);
+            // 크롤링 후 상품 고윳값으로 이미 등록된 상품인지 확인
+            Product existingProductByNum = null;
+            if (crawlerData.getProductNum() != null) {
+                existingProductByNum = productRepository.findByProductNum(crawlerData.getProductNum())
+                        .orElse(null);
+            }
             
-            if (existingProductByName != null) {
-                // 상품명으로 이미 등록된 상품이 있으면 상품URL을 현재 URL로 업데이트하고 updatedAt 갱신
-                productRepository.updateProductUrlAndUpdatedAt(existingProductByName.getProductId(), productUrl);
+            if (existingProductByNum != null) {
+                // 상품 고윳값으로 이미 등록된 상품이 있으면 상품URL을 현재 URL로 업데이트하고 updatedAt 갱신
+                productRepository.updateProductUrlAndUpdatedAt(existingProductByNum.getProductId(), productUrl, LocalDateTime.now());
                 // 업데이트 후 다시 조회하여 최신 정보 반환
-                Product updatedProduct = productRepository.findById(existingProductByName.getProductId())
-                        .orElse(existingProductByName);
+                Product updatedProduct = productRepository.findById(existingProductByNum.getProductId())
+                        .orElse(existingProductByNum);
                 return ProductConverter.toImportDTO(updatedProduct, true, true);
             }
 
@@ -529,7 +539,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             
             if (existingProductByUrl != null) {
                 // 기존 상품이 있으면 updatedAt을 현재 시간으로 업데이트
-                productRepository.updateUpdatedAt(existingProductByUrl.getProductId());
+                productRepository.updateUpdatedAt(existingProductByUrl.getProductId(), LocalDateTime.now());
                 // 업데이트 후 다시 조회하여 최신 정보 반환
                 Product updatedProduct = productRepository.findById(existingProductByUrl.getProductId())
                         .orElse(existingProductByUrl);
@@ -539,16 +549,19 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             // 크롤링 실행
             ProductCrawlingData crawlerData = crawlWconceptProduct(dto.getProduct_url());
 
-            // 크롤링 후 상품명으로 이미 등록된 상품인지 확인
-            Product existingProductByName = productRepository.findByProductName(crawlerData.getProductName())
-                    .orElse(null);
+            // 크롤링 후 상품 고윳값으로 이미 등록된 상품인지 확인
+            Product existingProductByNum = null;
+            if (crawlerData.getProductNum() != null) {
+                existingProductByNum = productRepository.findByProductNum(crawlerData.getProductNum())
+                        .orElse(null);
+            }
             
-            if (existingProductByName != null) {
-                // 상품명으로 이미 등록된 상품이 있으면 상품URL을 현재 URL로 업데이트하고 updatedAt 갱신
-                productRepository.updateProductUrlAndUpdatedAt(existingProductByName.getProductId(), productUrl);
+            if (existingProductByNum != null) {
+                // 상품 고윳값으로 이미 등록된 상품이 있으면 상품URL을 현재 URL로 업데이트하고 updatedAt 갱신
+                productRepository.updateProductUrlAndUpdatedAt(existingProductByNum.getProductId(), productUrl, LocalDateTime.now());
                 // 업데이트 후 다시 조회하여 최신 정보 반환
-                Product updatedProduct = productRepository.findById(existingProductByName.getProductId())
-                        .orElse(existingProductByName);
+                Product updatedProduct = productRepository.findById(existingProductByNum.getProductId())
+                        .orElse(existingProductByNum);
                 return ProductConverter.toImportDTO(updatedProduct, true, true);
             }
 

--- a/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
@@ -527,6 +527,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                     .price(crawlerData.getPrice())
                     .starPoint(crawlerData.getStarPoint())
                     .aiReview(crawlerData.getAiReview())
+                    .productNum(crawlerData.getProductNum())
                     .build();
 
             Product savedProduct = productRepository.save(product);
@@ -597,6 +598,24 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             
             data.setAiReview(jsonNode.has("AI_review") && !jsonNode.get("AI_review").isNull() ? 
                     jsonNode.get("AI_review").asText() : null);
+            
+            // product_num 처리
+            if (jsonNode.has("product_num") && !jsonNode.get("product_num").isNull()) {
+                JsonNode productNumNode = jsonNode.get("product_num");
+                if (productNumNode.isNumber()) {
+                    data.setProductNum(productNumNode.asLong());
+                } else if (productNumNode.isTextual()) {
+                    try {
+                        data.setProductNum(Long.parseLong(productNumNode.asText()));
+                    } catch (NumberFormatException e) {
+                        data.setProductNum(null);
+                    }
+                } else {
+                    data.setProductNum(null);
+                }
+            } else {
+                data.setProductNum(null);
+            }
             
             return data;
             

--- a/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
@@ -162,7 +162,24 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             
             data.setAiReview(jsonNode.has("AI_review") && !jsonNode.get("AI_review").isNull() ? 
                     jsonNode.get("AI_review").asText() : null);
-        
+            
+            // product_num 처리
+            if (jsonNode.has("product_num") && !jsonNode.get("product_num").isNull()) {
+                JsonNode productNumNode = jsonNode.get("product_num");
+                if (productNumNode.isNumber()) {
+                    data.setProductNum(productNumNode.asLong());
+                } else if (productNumNode.isTextual()) {
+                    try {
+                        data.setProductNum(Long.parseLong(productNumNode.asText()));
+                    } catch (NumberFormatException e) {
+                        data.setProductNum(null);
+                    }
+                } else {
+                    data.setProductNum(null);
+                }
+            } else {
+                data.setProductNum(null);
+            }
             
             return data;
             

--- a/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
@@ -443,8 +443,23 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             data.setAiReview(jsonNode.has("AI_review") && !jsonNode.get("AI_review").isNull() ? 
                     jsonNode.get("AI_review").asText() : null);
             
-            data.setProductNum(jsonNode.has("product_num") && !jsonNode.get("product_num").isNull() ? 
-                    jsonNode.get("product_num").asText() : null);
+            // product_num 처리
+            if (jsonNode.has("product_num") && !jsonNode.get("product_num").isNull()) {
+                JsonNode productNumNode = jsonNode.get("product_num");
+                if (productNumNode.isNumber()) {
+                    data.setProductNum(productNumNode.asLong());
+                } else if (productNumNode.isTextual()) {
+                    try {
+                        data.setProductNum(Long.parseLong(productNumNode.asText()));
+                    } catch (NumberFormatException e) {
+                        data.setProductNum(null);
+                    }
+                } else {
+                    data.setProductNum(null);
+                }
+            } else {
+                data.setProductNum(null);
+            }
             
             return data;
             
@@ -608,7 +623,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
         private String price;
         private Float starPoint;
         private String aiReview;
-        private String productNum;
+        private Long productNum;
 
     }
 }

--- a/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
@@ -10,7 +10,9 @@ import com.umc.EveryWear.domain.product.exception.ProductException;
 import com.umc.EveryWear.domain.product.exception.code.ProductErrorCode;
 import com.umc.EveryWear.domain.product.repository.ProductRepository;
 import jakarta.transaction.Transactional;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
@@ -89,6 +91,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                     .price(crawlerData.getPrice())
                     .starPoint(crawlerData.getStarPoint())
                     .aiReview(crawlerData.getAiReview())
+                    .productNum(crawlerData.getProductNum())
                     .build();
 
             Product savedProduct = productRepository.save(product);
@@ -159,6 +162,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             
             data.setAiReview(jsonNode.has("AI_review") && !jsonNode.get("AI_review").isNull() ? 
                     jsonNode.get("AI_review").asText() : null);
+        
             
             return data;
             
@@ -367,6 +371,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                     .price(crawlerData.getPrice())
                     .starPoint(crawlerData.getStarPoint())
                     .aiReview(crawlerData.getAiReview())
+                    .productNum(crawlerData.getProductNum())
                     .build();
 
             Product savedProduct = productRepository.save(product);
@@ -437,6 +442,9 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             
             data.setAiReview(jsonNode.has("AI_review") && !jsonNode.get("AI_review").isNull() ? 
                     jsonNode.get("AI_review").asText() : null);
+            
+            data.setProductNum(jsonNode.has("product_num") && !jsonNode.get("product_num").isNull() ? 
+                    jsonNode.get("product_num").asText() : null);
             
             return data;
             
@@ -587,8 +595,9 @@ public class ProductCommandServiceImpl implements ProductCommandService {
         }
     }
 
-
     // 크롤링 데이터를 담는 내부 클래스
+    @Setter
+    @Getter
     private static class ProductCrawlingData {
         private String shoppingmallName;
         private String productUrl;
@@ -599,25 +608,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
         private String price;
         private Float starPoint;
         private String aiReview;
+        private String productNum;
 
-        // Getters and Setters
-        public String getShoppingmallName() { return shoppingmallName; }
-        public void setShoppingmallName(String shoppingmallName) { this.shoppingmallName = shoppingmallName; }
-        public String getProductUrl() { return productUrl; }
-        public void setProductUrl(String productUrl) { this.productUrl = productUrl; }
-        public String getCategory() { return category; }
-        public void setCategory(String category) { this.category = category; }
-        public String getProductImgUrl() { return productImgUrl; }
-        public void setProductImgUrl(String productImgUrl) { this.productImgUrl = productImgUrl; }
-        public String getProductName() { return productName; }
-        public void setProductName(String productName) { this.productName = productName; }
-        public String getBrandName() { return brandName; }
-        public void setBrandName(String brandName) { this.brandName = brandName; }
-        public String getPrice() { return price; }
-        public void setPrice(String price) { this.price = price; }
-        public Float getStarPoint() { return starPoint; }
-        public void setStarPoint(Float starPoint) { this.starPoint = starPoint; }
-        public String getAiReview() { return aiReview; }
-        public void setAiReview(String aiReview) { this.aiReview = aiReview; }
     }
 }

--- a/src/main/java/com/umc/EveryWear/domain/user/entity/User.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/entity/User.java
@@ -1,10 +1,14 @@
 package com.umc.EveryWear.domain.user.entity;
 
+import com.umc.EveryWear.domain.product.entity.Product;
 import com.umc.EveryWear.domain.user.enums.UserStatus;
 import com.umc.EveryWear.domain.user.enums.SocialType;
 import com.umc.EveryWear.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "user")
@@ -44,10 +48,14 @@ public class User extends BaseEntity {
     @Column(name = "alarm_onoff", nullable = false)
     private Boolean alarmOnoff;
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Product> products = new ArrayList<>();
+
     @Builder
     public User(Long userId, String oauthId, String name, String email,
                 SocialType socialType, UserStatus isActive, String refreshToken,
-                Boolean isAgreed, Boolean alarmOnoff) {
+                Boolean isAgreed, Boolean alarmOnoff, List<Product> products) {
         this.userId = userId;
         this.oauthId = oauthId;
         this.name = name;
@@ -57,6 +65,7 @@ public class User extends BaseEntity {
         this.refreshToken = refreshToken;
         this.isAgreed = isAgreed;
         this.alarmOnoff = alarmOnoff;
+        this.products = products != null ? products : new ArrayList<>();
     }
 
     // Refresh Token 업데이트 메서드


### PR DESCRIPTION
#46 여기에 상품 등록과 조회 병합해서 close 합니다.

## 🔗 Related Issue
- resolve #37 
- resolve #43 

## ✨ 작업 개요
> 네가지 쇼핑몰의 상품 고유 번호를 FAST API를 통해 받아오고 DB에 저장합니다.
상품 등록 시 상품 고유 번호로 재등록 여부를 판단하여, 중복 상품 등록을 방지합니다.
추가적으로 상품 등록이 전역인 점을 수정했습니다. 유저와 상품 엔터티 연관관계 매핑을 추가해, 유저가 등록한 상품만 볼 수 있도록 하였습니다.

## 📷 이미지 첨부 (선택)
<img width="1755" height="781" alt="image" src="https://github.com/user-attachments/assets/84193afe-64db-43f6-86fc-098f1d08465c" />
<img width="1762" height="783" alt="image" src="https://github.com/user-attachments/assets/8ceac862-5e8e-47b0-a4f8-34d503d7ffa5" />
<img width="1761" height="863" alt="image" src="https://github.com/user-attachments/assets/c0991681-8697-48fc-b5de-c8aadaee2641" />
<img width="1755" height="773" alt="image" src="https://github.com/user-attachments/assets/42524b63-ab3e-47a5-8fda-2720a97e385f" />
<img width="1757" height="782" alt="image" src="https://github.com/user-attachments/assets/247e527a-408b-4c5d-898b-5d6dc6d3bca8" />
<img width="1752" height="778" alt="image" src="https://github.com/user-attachments/assets/3cf16bb7-5ae4-4274-a5b6-bf68aedbeb98" />
<img width="1747" height="772" alt="image" src="https://github.com/user-attachments/assets/4ac2202c-194b-4393-8cf2-ab09a97cc864" />

## 🧐 집중 리뷰 요청
> 기존 erd가 상품을 미리 DB에 저장해 두는 방식이어서, 상품 등록 하나를 하면 유저 전체한테 등록이 되었습니다. 그래서 유저 엔터티와 상품 엔터티 연관관계를 추가했습니다.
