### PR TITLE
[Feat] 사용자 상품 테이블 분리

### DIFF
--- a/src/main/java/com/umc/EveryWear/domain/fitting/exception/FittingException.java
+++ b/src/main/java/com/umc/EveryWear/domain/fitting/exception/FittingException.java
@@ -1,7 +1,4 @@
 package com.umc.EveryWear.domain.fitting.exception;
 
-public class FittingException extends RuntimeException {
-    public FittingException(String message) {
-        super(message);
-    }
+public class FittingException {
 }

--- a/src/main/java/com/umc/EveryWear/domain/fitting/repository/FittingRepository.java
+++ b/src/main/java/com/umc/EveryWear/domain/fitting/repository/FittingRepository.java
@@ -1,37 +1,7 @@
 package com.umc.EveryWear.domain.fitting.repository;
 
-import com.umc.EveryWear.domain.fitting.entity.FittingHistory;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface FittingRepository {
-
-    // 사용자별 상품 조회 (updatedAt 내림차순)
-    @Query("SELECT fh.product FROM FittingHistory fh WHERE fh.user.userId = :userId ORDER BY fh.updatedAt DESC")
-    List<com.umc.EveryWear.domain.product.entity.Product> findAllProductsByUserIdOrderByUpdatedAtDesc(@Param("userId") Long userId);
-
-    // 사용자별 카테고리별 상품 조회 (updatedAt 내림차순)
-    @Query("SELECT fh.product FROM FittingHistory fh WHERE fh.user.userId = :userId AND fh.product.category = :category ORDER BY fh.updatedAt DESC")
-    List<com.umc.EveryWear.domain.product.entity.Product> findProductsByUserIdAndCategoryOrderByUpdatedAtDesc(@Param("userId") Long userId, @Param("category") String category);
-
-    // 사용자별 상품 조회 상위 6개 (updatedAt 내림차순)
-    @Query("SELECT fh.product FROM FittingHistory fh WHERE fh.user.userId = :userId ORDER BY fh.updatedAt DESC")
-    List<com.umc.EveryWear.domain.product.entity.Product> findTop6ProductsByUserIdOrderByUpdatedAtDesc(@Param("userId") Long userId, Pageable pageable);
-
-    // 특정 사용자와 상품으로 FittingHistory 조회
-    Optional<FittingHistory> findByUser_UserIdAndProduct_ProductId(Long userId, Long productId);
-
-    // updatedAt을 현재 시간으로 업데이트
-    @Modifying
-    @Query("UPDATE FittingHistory fh SET fh.updatedAt = :updatedAt WHERE fh.user.userId = :userId AND fh.product.productId = :productId")
-    void updateUpdatedAt(@Param("userId") Long userId, @Param("productId") Long productId, @Param("updatedAt") LocalDateTime updatedAt);
 }

--- a/src/main/java/com/umc/EveryWear/domain/home/service/query/HomeQueryServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/home/service/query/HomeQueryServiceImpl.java
@@ -3,7 +3,7 @@ package com.umc.EveryWear.domain.home.service.query;
 import com.umc.EveryWear.domain.home.converter.HomeConverter;
 import com.umc.EveryWear.domain.home.dto.res.HomeResDTO;
 import com.umc.EveryWear.domain.product.entity.Product;
-import com.umc.EveryWear.domain.fitting.repository.FittingRepository;
+import com.umc.EveryWear.domain.user.repository.UserProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -18,12 +18,12 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class HomeQueryServiceImpl implements HomeQueryService {
 
-    private final FittingRepository fittingRepository;
+    private final UserProductRepository userProductRepository;
 
     @Override
     public HomeResDTO.ProductListResponse getHomeProducts(Long userId) {
         Pageable pageable = PageRequest.of(0, 6);
-        List<Product> products = fittingRepository.findTop6ProductsByUserIdOrderByUpdatedAtDesc(userId, pageable);
+        List<Product> products = userProductRepository.findTop6ProductsByUserIdOrderByUpdatedAtDesc(userId, pageable);
         
         List<HomeResDTO.ProductDTO> productList = products.stream()
                 .map(HomeConverter::toProductDTO)

--- a/src/main/java/com/umc/EveryWear/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/repository/ProductRepository.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
     // 전역 상품 조회 (user_id 무관)
+    // 상품 등록 여부판단에 사용
     Optional<Product> findByProductUrl(String productUrl);
     Optional<Product> findByProductNum(Long productNum);
 }

--- a/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
@@ -260,22 +260,20 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                     .orElse(null);
             
             if (existingProductByUrl != null) {
-                // 기존 상품이 있으면 FittingHistory에 이미 등록되어 있는지 확인
-                FittingHistory existingFittingHistory = fittingRepository.findByUser_UserIdAndProduct_ProductId(userId, existingProductByUrl.getProductId())
+                // 기존 상품이 있으면 UserProduct에 이미 등록되어 있는지 확인
+                UserProduct existingUserProduct = userProductRepository.findByUser_UserIdAndProduct_ProductId(userId, existingProductByUrl.getProductId())
                         .orElse(null);
                 
-                if (existingFittingHistory == null) {
-                    // FittingHistory에 없으면 새로 생성
-                    FittingHistory fittingHistory = FittingHistory.builder()
+                if (existingUserProduct == null) {
+                    // UserProduct에 없으면 새로 생성 (BaseEntity가 자동으로 createdAt, updatedAt 설정)
+                    UserProduct userProduct = UserProduct.builder()
                             .user(user)
                             .product(existingProductByUrl)
-                            .fittingResultImage(null)
-                            .isLiked(false)
                             .build();
-                    fittingRepository.save(fittingHistory);
+                    userProductRepository.save(userProduct);
                 } else {
-                    // 기존 FittingHistory가 있으면 updated_at을 현재 시간으로 업데이트
-                    fittingRepository.updateUpdatedAt(userId, existingProductByUrl.getProductId(), LocalDateTime.now());
+                    // 기존 UserProduct가 있으면 updated_at을 현재 시간으로 업데이트
+                    userProductRepository.updateUpdatedAt(userId, existingProductByUrl.getProductId(), LocalDateTime.now());
                 }
                 return ProductConverter.toImportDTO(existingProductByUrl, true);
             }
@@ -461,22 +459,20 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                     .orElse(null);
             
             if (existingProductByUrl != null) {
-                // 기존 상품이 있으면 FittingHistory에 이미 등록되어 있는지 확인
-                FittingHistory existingFittingHistory = fittingRepository.findByUser_UserIdAndProduct_ProductId(userId, existingProductByUrl.getProductId())
+                // 기존 상품이 있으면 UserProduct에 이미 등록되어 있는지 확인
+                UserProduct existingUserProduct = userProductRepository.findByUser_UserIdAndProduct_ProductId(userId, existingProductByUrl.getProductId())
                         .orElse(null);
                 
-                if (existingFittingHistory == null) {
-                    // FittingHistory에 없으면 새로 생성
-                    FittingHistory fittingHistory = FittingHistory.builder()
+                if (existingUserProduct == null) {
+                    // UserProduct에 없으면 새로 생성 (BaseEntity가 자동으로 createdAt, updatedAt 설정)
+                    UserProduct userProduct = UserProduct.builder()
                             .user(user)
                             .product(existingProductByUrl)
-                            .fittingResultImage(null)
-                            .isLiked(false)
                             .build();
-                    fittingRepository.save(fittingHistory);
+                    userProductRepository.save(userProduct);
                 } else {
-                    // 기존 FittingHistory가 있으면 updated_at을 현재 시간으로 업데이트
-                    fittingRepository.updateUpdatedAt(userId, existingProductByUrl.getProductId(), LocalDateTime.now());
+                    // 기존 UserProduct가 있으면 updated_at을 현재 시간으로 업데이트
+                    userProductRepository.updateUpdatedAt(userId, existingProductByUrl.getProductId(), LocalDateTime.now());
                 }
                 return ProductConverter.toImportDTO(existingProductByUrl, true);
             }
@@ -657,22 +653,20 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                     .orElse(null);
             
             if (existingProductByUrl != null) {
-                // 기존 상품이 있으면 FittingHistory에 이미 등록되어 있는지 확인
-                FittingHistory existingFittingHistory = fittingRepository.findByUser_UserIdAndProduct_ProductId(userId, existingProductByUrl.getProductId())
+                // 기존 상품이 있으면 UserProduct에 이미 등록되어 있는지 확인
+                UserProduct existingUserProduct = userProductRepository.findByUser_UserIdAndProduct_ProductId(userId, existingProductByUrl.getProductId())
                         .orElse(null);
                 
-                if (existingFittingHistory == null) {
-                    // FittingHistory에 없으면 새로 생성
-                    FittingHistory fittingHistory = FittingHistory.builder()
+                if (existingUserProduct == null) {
+                    // UserProduct에 없으면 새로 생성 (BaseEntity가 자동으로 createdAt, updatedAt 설정)
+                    UserProduct userProduct = UserProduct.builder()
                             .user(user)
                             .product(existingProductByUrl)
-                            .fittingResultImage(null)
-                            .isLiked(false)
                             .build();
-                    fittingRepository.save(fittingHistory);
+                    userProductRepository.save(userProduct);
                 } else {
-                    // 기존 FittingHistory가 있으면 updated_at을 현재 시간으로 업데이트
-                    fittingRepository.updateUpdatedAt(userId, existingProductByUrl.getProductId(), LocalDateTime.now());
+                    // 기존 UserProduct가 있으면 updated_at을 현재 시간으로 업데이트
+                    userProductRepository.updateUpdatedAt(userId, existingProductByUrl.getProductId(), LocalDateTime.now());
                 }
                 return ProductConverter.toImportDTO(existingProductByUrl, true);
             }

--- a/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
@@ -9,8 +9,8 @@ import com.umc.EveryWear.domain.product.entity.Product;
 import com.umc.EveryWear.domain.product.exception.ProductException;
 import com.umc.EveryWear.domain.product.exception.code.ProductErrorCode;
 import com.umc.EveryWear.domain.product.repository.ProductRepository;
-import com.umc.EveryWear.domain.fitting.entity.FittingHistory;
-import com.umc.EveryWear.domain.fitting.repository.FittingRepository;
+import com.umc.EveryWear.domain.user.entity.mapping.UserProduct;
+import com.umc.EveryWear.domain.user.repository.UserProductRepository;
 import com.umc.EveryWear.domain.user.entity.User;
 import com.umc.EveryWear.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -38,7 +38,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
 
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
-    private final FittingRepository fittingRepository;
+    private final UserProductRepository userProductRepository;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final WebClient webClient;
     
@@ -48,7 +48,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
     @Override
     public ProductResDTO.ImportDTO importMusinsaProduct(Long userId, ProductReqDTO.ImportMusinsaDTO dto) {
         try {
-            // User 조회 (FittingHistory에 저장하기 위해)
+            // User 조회 (UserProduct에 저장하기 위해)
             User user = userRepository.findById(userId)
                     .orElseThrow(() -> new ProductException(ProductErrorCode.CRAWLING_FAILED));
             
@@ -67,22 +67,20 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                     .orElse(null);
             
             if (existingProductByUrl != null) {
-                // 기존 상품이 있으면 FittingHistory에 이미 등록되어 있는지 확인
-                FittingHistory existingFittingHistory = fittingRepository.findByUser_UserIdAndProduct_ProductId(userId, existingProductByUrl.getProductId())
+                // 기존 상품이 있으면 UserProduct에 이미 등록되어 있는지 확인
+                UserProduct existingUserProduct = userProductRepository.findByUser_UserIdAndProduct_ProductId(userId, existingProductByUrl.getProductId())
                         .orElse(null);
                 
-                if (existingFittingHistory == null) {
-                    // FittingHistory에 없으면 새로 생성 (BaseEntity가 자동으로 createdAt, updatedAt 설정)
-                    FittingHistory fittingHistory = FittingHistory.builder()
+                if (existingUserProduct == null) {
+                    // UserProduct에 없으면 새로 생성 (BaseEntity가 자동으로 createdAt, updatedAt 설정)
+                    UserProduct userProduct = UserProduct.builder()
                             .user(user)
                             .product(existingProductByUrl)
-                            .fittingResultImage(null)
-                            .isLiked(false)
                             .build();
-                    fittingRepository.save(fittingHistory);
+                    userProductRepository.save(userProduct);
                 } else {
-                    // 기존 FittingHistory가 있으면 updated_at을 현재 시간으로 업데이트
-                    fittingRepository.updateUpdatedAt(userId, existingProductByUrl.getProductId(), LocalDateTime.now());
+                    // 기존 UserProduct가 있으면 updated_at을 현재 시간으로 업데이트
+                    userProductRepository.updateUpdatedAt(userId, existingProductByUrl.getProductId(), LocalDateTime.now());
                 }
                 return ProductConverter.toImportDTO(existingProductByUrl, true);
             }
@@ -102,22 +100,20 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                 existingProductByNum.updateProductUrl(productUrl);
                 Product updatedProduct = productRepository.save(existingProductByNum);
                 
-                // FittingHistory에 이미 등록되어 있는지 확인
-                FittingHistory existingFittingHistory = fittingRepository.findByUser_UserIdAndProduct_ProductId(userId, updatedProduct.getProductId())
+                // UserProduct에 이미 등록되어 있는지 확인
+                UserProduct existingUserProduct = userProductRepository.findByUser_UserIdAndProduct_ProductId(userId, updatedProduct.getProductId())
                         .orElse(null);
                 
-                if (existingFittingHistory == null) {
-                    // FittingHistory에 없으면 새로 생성
-                    FittingHistory fittingHistory = FittingHistory.builder()
+                if (existingUserProduct == null) {
+                    // UserProduct에 없으면 새로 생성
+                    UserProduct userProduct = UserProduct.builder()
                             .user(user)
                             .product(updatedProduct)
-                            .fittingResultImage(null)
-                            .isLiked(false)
                             .build();
-                    fittingRepository.save(fittingHistory);
+                    userProductRepository.save(userProduct);
                 } else {
-                    // 기존 FittingHistory가 있으면 updated_at을 현재 시간으로 업데이트
-                    fittingRepository.updateUpdatedAt(userId, updatedProduct.getProductId(), LocalDateTime.now());
+                    // 기존 UserProduct가 있으면 updated_at을 현재 시간으로 업데이트
+                    userProductRepository.updateUpdatedAt(userId, updatedProduct.getProductId(), LocalDateTime.now());
                 }
                 return ProductConverter.toImportDTO(updatedProduct, true, true);
             }
@@ -138,14 +134,12 @@ public class ProductCommandServiceImpl implements ProductCommandService {
 
             Product savedProduct = productRepository.save(product);
             
-            // FittingHistory에 저장
-            FittingHistory fittingHistory = FittingHistory.builder()
+            // UserProduct에 저장
+            UserProduct userProduct = UserProduct.builder()
                     .user(user)
                     .product(savedProduct)
-                    .fittingResultImage(null)
-                    .isLiked(false)
                     .build();
-            fittingRepository.save(fittingHistory);
+            userProductRepository.save(userProduct);
 
             return ProductConverter.toImportDTO(savedProduct);
 
@@ -247,7 +241,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
     @Override
     public ProductResDTO.ImportDTO importZigzagProduct(Long userId, ProductReqDTO.ImportZigzagDTO dto) {
         try {
-            // User 조회 (FittingHistory에 저장하기 위해)
+            // User 조회 (UserProduct에 저장하기 위해)
             User user = userRepository.findById(userId)
                     .orElseThrow(() -> new ProductException(ProductErrorCode.CRAWLING_FAILED));
             
@@ -301,22 +295,20 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                 existingProductByNum.updateProductUrl(productUrl);
                 Product updatedProduct = productRepository.save(existingProductByNum);
                 
-                // FittingHistory에 이미 등록되어 있는지 확인
-                FittingHistory existingFittingHistory = fittingRepository.findByUser_UserIdAndProduct_ProductId(userId, updatedProduct.getProductId())
+                // UserProduct에 이미 등록되어 있는지 확인
+                UserProduct existingUserProduct = userProductRepository.findByUser_UserIdAndProduct_ProductId(userId, updatedProduct.getProductId())
                         .orElse(null);
                 
-                if (existingFittingHistory == null) {
-                    // FittingHistory에 없으면 새로 생성
-                    FittingHistory fittingHistory = FittingHistory.builder()
+                if (existingUserProduct == null) {
+                    // UserProduct에 없으면 새로 생성
+                    UserProduct userProduct = UserProduct.builder()
                             .user(user)
                             .product(updatedProduct)
-                            .fittingResultImage(null)
-                            .isLiked(false)
                             .build();
-                    fittingRepository.save(fittingHistory);
+                    userProductRepository.save(userProduct);
                 } else {
-                    // 기존 FittingHistory가 있으면 updated_at을 현재 시간으로 업데이트
-                    fittingRepository.updateUpdatedAt(userId, updatedProduct.getProductId(), LocalDateTime.now());
+                    // 기존 UserProduct가 있으면 updated_at을 현재 시간으로 업데이트
+                    userProductRepository.updateUpdatedAt(userId, updatedProduct.getProductId(), LocalDateTime.now());
                 }
                 return ProductConverter.toImportDTO(updatedProduct, true, true);
             }
@@ -337,14 +329,12 @@ public class ProductCommandServiceImpl implements ProductCommandService {
 
             Product savedProduct = productRepository.save(product);
             
-            // FittingHistory에 저장
-            FittingHistory fittingHistory = FittingHistory.builder()
+            // UserProduct에 저장
+            UserProduct userProduct = UserProduct.builder()
                     .user(user)
                     .product(savedProduct)
-                    .fittingResultImage(null)
-                    .isLiked(false)
                     .build();
-            fittingRepository.save(fittingHistory);
+            userProductRepository.save(userProduct);
 
             return ProductConverter.toImportDTO(savedProduct);
 
@@ -452,7 +442,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
     @Override
     public ProductResDTO.ImportDTO import29cmProduct(Long userId, ProductReqDTO.Import29cmDTO dto) {
         try {
-            // User 조회 (FittingHistory에 저장하기 위해)
+            // User 조회 (UserProduct에 저장하기 위해)
             User user = userRepository.findById(userId)
                     .orElseThrow(() -> new ProductException(ProductErrorCode.CRAWLING_FAILED));
             
@@ -506,22 +496,20 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                 existingProductByNum.updateProductUrl(productUrl);
                 Product updatedProduct = productRepository.save(existingProductByNum);
                 
-                // FittingHistory에 이미 등록되어 있는지 확인
-                FittingHistory existingFittingHistory = fittingRepository.findByUser_UserIdAndProduct_ProductId(userId, updatedProduct.getProductId())
+                // UserProduct에 이미 등록되어 있는지 확인
+                UserProduct existingUserProduct = userProductRepository.findByUser_UserIdAndProduct_ProductId(userId, updatedProduct.getProductId())
                         .orElse(null);
                 
-                if (existingFittingHistory == null) {
-                    // FittingHistory에 없으면 새로 생성
-                    FittingHistory fittingHistory = FittingHistory.builder()
+                if (existingUserProduct == null) {
+                    // UserProduct에 없으면 새로 생성
+                    UserProduct userProduct = UserProduct.builder()
                             .user(user)
                             .product(updatedProduct)
-                            .fittingResultImage(null)
-                            .isLiked(false)
                             .build();
-                    fittingRepository.save(fittingHistory);
+                    userProductRepository.save(userProduct);
                 } else {
-                    // 기존 FittingHistory가 있으면 updated_at을 현재 시간으로 업데이트
-                    fittingRepository.updateUpdatedAt(userId, updatedProduct.getProductId(), LocalDateTime.now());
+                    // 기존 UserProduct가 있으면 updated_at을 현재 시간으로 업데이트
+                    userProductRepository.updateUpdatedAt(userId, updatedProduct.getProductId(), LocalDateTime.now());
                 }
                 return ProductConverter.toImportDTO(updatedProduct, true, true);
             }
@@ -542,14 +530,12 @@ public class ProductCommandServiceImpl implements ProductCommandService {
 
             Product savedProduct = productRepository.save(product);
             
-            // FittingHistory에 저장
-            FittingHistory fittingHistory = FittingHistory.builder()
+            // UserProduct에 저장
+            UserProduct userProduct = UserProduct.builder()
                     .user(user)
                     .product(savedProduct)
-                    .fittingResultImage(null)
-                    .isLiked(false)
                     .build();
-            fittingRepository.save(fittingHistory);
+            userProductRepository.save(userProduct);
 
             return ProductConverter.toImportDTO(savedProduct);
 
@@ -652,7 +638,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
     @Override
     public ProductResDTO.ImportDTO importWconceptProduct(Long userId, ProductReqDTO.WconceptImportDTO dto) {
         try {
-            // User 조회 (FittingHistory에 저장하기 위해)
+            // User 조회 (UserProduct에 저장하기 위해)
             User user = userRepository.findById(userId)
                     .orElseThrow(() -> new ProductException(ProductErrorCode.CRAWLING_FAILED));
             
@@ -706,22 +692,20 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                 existingProductByNum.updateProductUrl(productUrl);
                 Product updatedProduct = productRepository.save(existingProductByNum);
                 
-                // FittingHistory에 이미 등록되어 있는지 확인
-                FittingHistory existingFittingHistory = fittingRepository.findByUser_UserIdAndProduct_ProductId(userId, updatedProduct.getProductId())
+                // UserProduct에 이미 등록되어 있는지 확인
+                UserProduct existingUserProduct = userProductRepository.findByUser_UserIdAndProduct_ProductId(userId, updatedProduct.getProductId())
                         .orElse(null);
                 
-                if (existingFittingHistory == null) {
-                    // FittingHistory에 없으면 새로 생성
-                    FittingHistory fittingHistory = FittingHistory.builder()
+                if (existingUserProduct == null) {
+                    // UserProduct에 없으면 새로 생성
+                    UserProduct userProduct = UserProduct.builder()
                             .user(user)
                             .product(updatedProduct)
-                            .fittingResultImage(null)
-                            .isLiked(false)
                             .build();
-                    fittingRepository.save(fittingHistory);
+                    userProductRepository.save(userProduct);
                 } else {
-                    // 기존 FittingHistory가 있으면 updated_at을 현재 시간으로 업데이트
-                    fittingRepository.updateUpdatedAt(userId, updatedProduct.getProductId(), LocalDateTime.now());
+                    // 기존 UserProduct가 있으면 updated_at을 현재 시간으로 업데이트
+                    userProductRepository.updateUpdatedAt(userId, updatedProduct.getProductId(), LocalDateTime.now());
                 }
                 return ProductConverter.toImportDTO(updatedProduct, true, true);
             }
@@ -742,14 +726,12 @@ public class ProductCommandServiceImpl implements ProductCommandService {
 
             Product savedProduct = productRepository.save(product);
             
-            // FittingHistory에 저장
-            FittingHistory fittingHistory = FittingHistory.builder()
+            // UserProduct에 저장
+            UserProduct userProduct = UserProduct.builder()
                     .user(user)
                     .product(savedProduct)
-                    .fittingResultImage(null)
-                    .isLiked(false)
                     .build();
-            fittingRepository.save(fittingHistory);
+            userProductRepository.save(userProduct);
 
             return ProductConverter.toImportDTO(savedProduct);
 

--- a/src/main/java/com/umc/EveryWear/domain/product/service/query/ProductQueryServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/query/ProductQueryServiceImpl.java
@@ -3,7 +3,7 @@ package com.umc.EveryWear.domain.product.service.query;
 import com.umc.EveryWear.domain.product.converter.ProductConverter;
 import com.umc.EveryWear.domain.product.dto.res.ProductResDTO;
 import com.umc.EveryWear.domain.product.entity.Product;
-import com.umc.EveryWear.domain.fitting.repository.FittingRepository;
+import com.umc.EveryWear.domain.user.repository.UserProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,11 +16,11 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class ProductQueryServiceImpl implements ProductQueryService {
 
-    private final FittingRepository fittingRepository;
+    private final UserProductRepository userProductRepository;
 
     @Override
     public ProductResDTO.ProductListResponse getAllProductsByUserId(Long userId) {
-        List<Product> products = fittingRepository.findAllProductsByUserIdOrderByUpdatedAtDesc(userId);
+        List<Product> products = userProductRepository.findAllProductsByUserIdOrderByUpdatedAtDesc(userId);
         
         List<ProductResDTO.ListDTO> productList = products.stream()
                 .map(ProductConverter::toListDTO)
@@ -33,7 +33,7 @@ public class ProductQueryServiceImpl implements ProductQueryService {
 
     @Override
     public ProductResDTO.ProductListResponse getProductsByCategory(Long userId, String category) {
-        List<Product> products = fittingRepository.findProductsByUserIdAndCategoryOrderByUpdatedAtDesc(userId, category);
+        List<Product> products = userProductRepository.findProductsByUserIdAndCategoryOrderByUpdatedAtDesc(userId, category);
         
         List<ProductResDTO.ListDTO> productList = products.stream()
                 .map(ProductConverter::toListDTO)

--- a/src/main/java/com/umc/EveryWear/domain/user/controller/UserProductController.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/controller/UserProductController.java
@@ -1,0 +1,4 @@
+package com.umc.EveryWear.domain.user.controller;
+
+public class UserProductController {
+}

--- a/src/main/java/com/umc/EveryWear/domain/user/converter/UserProductConverter.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/converter/UserProductConverter.java
@@ -1,0 +1,4 @@
+package com.umc.EveryWear.domain.user.converter;
+
+public class UserProductConverter {
+}

--- a/src/main/java/com/umc/EveryWear/domain/user/entity/mapping/UserProduct.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/entity/mapping/UserProduct.java
@@ -1,0 +1,30 @@
+package com.umc.EveryWear.domain.user.entity.mapping;
+
+import com.umc.EveryWear.domain.user.entity.User;
+import com.umc.EveryWear.domain.product.entity.Product;
+import com.umc.EveryWear.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "user_product")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserProduct extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_product_id")
+    private Long userProductId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+}
+

--- a/src/main/java/com/umc/EveryWear/domain/user/exception/UserProductException.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/exception/UserProductException.java
@@ -1,0 +1,7 @@
+package com.umc.EveryWear.domain.user.exception;
+
+public class UserProductException extends RuntimeException {
+    public UserProductException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/umc/EveryWear/domain/user/exception/code/UserProductErrorCode.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/exception/code/UserProductErrorCode.java
@@ -1,0 +1,4 @@
+package com.umc.EveryWear.domain.user.exception.code;
+
+public enum UserProductErrorCode {
+}

--- a/src/main/java/com/umc/EveryWear/domain/user/exception/code/UserProductSuccessCode.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/exception/code/UserProductSuccessCode.java
@@ -1,0 +1,4 @@
+package com.umc.EveryWear.domain.user.exception.code;
+
+public enum UserProductSuccessCode {
+}

--- a/src/main/java/com/umc/EveryWear/domain/user/repository/UserProductRepository.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/repository/UserProductRepository.java
@@ -1,6 +1,6 @@
-package com.umc.EveryWear.domain.fitting.repository;
+package com.umc.EveryWear.domain.user.repository;
 
-import com.umc.EveryWear.domain.fitting.entity.FittingHistory;
+import com.umc.EveryWear.domain.user.entity.mapping.UserProduct;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -13,25 +13,25 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface FittingRepository {
-
+public interface UserProductRepository extends JpaRepository<UserProduct, Long> {
+    
     // 사용자별 상품 조회 (updatedAt 내림차순)
-    @Query("SELECT fh.product FROM FittingHistory fh WHERE fh.user.userId = :userId ORDER BY fh.updatedAt DESC")
+    @Query("SELECT up.product FROM UserProduct up WHERE up.user.userId = :userId ORDER BY up.updatedAt DESC")
     List<com.umc.EveryWear.domain.product.entity.Product> findAllProductsByUserIdOrderByUpdatedAtDesc(@Param("userId") Long userId);
-
+    
     // 사용자별 카테고리별 상품 조회 (updatedAt 내림차순)
-    @Query("SELECT fh.product FROM FittingHistory fh WHERE fh.user.userId = :userId AND fh.product.category = :category ORDER BY fh.updatedAt DESC")
+    @Query("SELECT up.product FROM UserProduct up WHERE up.user.userId = :userId AND up.product.category = :category ORDER BY up.updatedAt DESC")
     List<com.umc.EveryWear.domain.product.entity.Product> findProductsByUserIdAndCategoryOrderByUpdatedAtDesc(@Param("userId") Long userId, @Param("category") String category);
-
+    
     // 사용자별 상품 조회 상위 6개 (updatedAt 내림차순)
-    @Query("SELECT fh.product FROM FittingHistory fh WHERE fh.user.userId = :userId ORDER BY fh.updatedAt DESC")
+    @Query("SELECT up.product FROM UserProduct up WHERE up.user.userId = :userId ORDER BY up.updatedAt DESC")
     List<com.umc.EveryWear.domain.product.entity.Product> findTop6ProductsByUserIdOrderByUpdatedAtDesc(@Param("userId") Long userId, Pageable pageable);
-
-    // 특정 사용자와 상품으로 FittingHistory 조회
-    Optional<FittingHistory> findByUser_UserIdAndProduct_ProductId(Long userId, Long productId);
-
+    
+    // 특정 사용자와 상품으로 UserProduct 조회
+    Optional<UserProduct> findByUser_UserIdAndProduct_ProductId(Long userId, Long productId);
+    
     // updatedAt을 현재 시간으로 업데이트
     @Modifying
-    @Query("UPDATE FittingHistory fh SET fh.updatedAt = :updatedAt WHERE fh.user.userId = :userId AND fh.product.productId = :productId")
+    @Query("UPDATE UserProduct up SET up.updatedAt = :updatedAt WHERE up.user.userId = :userId AND up.product.productId = :productId")
     void updateUpdatedAt(@Param("userId") Long userId, @Param("productId") Long productId, @Param("updatedAt") LocalDateTime updatedAt);
 }


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #47 

## ✨ 작업 개요
> 사용자 상품 테이블을 생성하여 상품 등록과 조회를 분리해 관리합니다.
기존 fittinghistory 관련 코드를 삭제하고, user_product로 대체하였습니다.

## 체크리스트
- [x] 신규 무신사 상품 user_product 테이블 등록
- [x] 신규 지그재그 상품 user_product 테이블 등록
- [x] 신규 29cm 상품 user_product 테이블 등록
- [x] 신규 w컨셉 상품 user_product 테이블 등록
- [x] 기존 무신사 상품 user_product 테이블 등록 (이미 product 테이블에 등록된 상품을 user_product로 등록)
- [x] 기존 지그재그 상품 user_product 테이블 등록 (이미 product 테이블에 등록된 상품을 user_product로 등록)
- [x] 기존 29cm 상품 user_product 테이블 등록 (이미 product 테이블에 등록된 상품을 user_product로 등록)
- [x] 기존  w컨셉 상품 user_product 테이블 등록 (이미 product 테이블에 등록된 상품을 user_product로 등록)
- [x] 무신사 상품 시간 업데이트
- [x] 지그재그 상품 시간 업데이트
- [x] 29cm 상품 시간 업데이트
- [x] w컨셉 상품 시간 업데이트
- [x] 리다이랙트가 필요한 무신사 상품 URL이 user_product 테이블에 등록되는지 확인
- [x] 리다이랙트가 필요한 지그재그 상품 URL이 user_product 테이블에 등록되는지 확인
- [x] 리다이랙트가 필요한 29cm 상품 URL이 user_product 테이블에 등록되는지 확인
- [x] 리다이랙트가 필요한 w컨셉 상품 URL이 user_product 테이블에 등록되는지 확인
- [x] 인증한 user_id 값이 상품 등록 시 해당 컬럼에 정상적으로 저장되는지 확인
- [x] 상품 최신순 조회

## 📷 이미지 첨부 (선택)
- 등록
<img width="1763" height="786" alt="image" src="https://github.com/user-attachments/assets/5f82242d-61bc-4fad-bc59-27e4ad23dd95" />

- 조회
<img width="1767" height="872" alt="image" src="https://github.com/user-attachments/assets/5a2be91a-ab35-4a71-8487-a96e0dbee872" />


## 🧐 집중 리뷰 요청
> `https://www.musinsa.com/products/5839344` 이 링크 api/product/import/musinsa 바디에 넣어서 실행해 보시구, DB user_product 테이블에 본인 user_id로 잘 들어가는지 확인해 주세요!