### PR TITLE
[Feat] 유저-상품 테이블과 피팅 내역 테이블 1:n 연결

### DIFF
--- a/src/main/java/com/umc/EveryWear/domain/fitting/entity/FittingHistory.java
+++ b/src/main/java/com/umc/EveryWear/domain/fitting/entity/FittingHistory.java
@@ -6,7 +6,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "fittingHistory")
+@Table(name = "fitting_history")
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/umc/EveryWear/domain/fitting/entity/FittingHistory.java
+++ b/src/main/java/com/umc/EveryWear/domain/fitting/entity/FittingHistory.java
@@ -1,7 +1,6 @@
 package com.umc.EveryWear.domain.fitting.entity;
 
-import com.umc.EveryWear.domain.user.entity.User;
-import com.umc.EveryWear.domain.product.entity.Product;
+import com.umc.EveryWear.domain.user.entity.mapping.UserProduct;
 import com.umc.EveryWear.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -20,18 +19,14 @@ public class FittingHistory extends BaseEntity {
     private Long fittingId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "product_id", nullable = false)
-    private Product product;
+    @JoinColumn(name = "user_product_id", nullable = false)
+    private UserProduct userProduct;
 
     @Column(name = "fitting_result_image")
     private String fittingResultImage;
 
-    @Column(name = "is_liked", nullable = false)
-    @Builder.Default
-    private Boolean isLiked = false;
+    public void applyFittingResult(String imageUrl) {
+        this.fittingResultImage = imageUrl;
+    }
 }
 

--- a/src/main/java/com/umc/EveryWear/domain/user/entity/mapping/UserProduct.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/entity/mapping/UserProduct.java
@@ -1,10 +1,14 @@
 package com.umc.EveryWear.domain.user.entity.mapping;
 
+import com.umc.EveryWear.domain.fitting.entity.FittingHistory;
 import com.umc.EveryWear.domain.user.entity.User;
 import com.umc.EveryWear.domain.product.entity.Product;
 import com.umc.EveryWear.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "user_product")
@@ -26,5 +30,13 @@ public class UserProduct extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
+
+    @Column(name = "is_liked", nullable = false)
+    @Builder.Default
+    private Boolean isLiked = false;
+
+    @OneToMany(mappedBy = "userProduct", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<FittingHistory> fittingHistories = new ArrayList<>();
 }
 


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #50 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.
ERD 수정에 따라 유저-상품 엔티티와 피팅 내역 엔티티를 1:n으로 연결했습니다

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.