### PR TITLE
[Feat] 상품 삭제

### DIFF
--- a/src/main/java/com/umc/EveryWear/EveryWearApplication.java
+++ b/src/main/java/com/umc/EveryWear/EveryWearApplication.java
@@ -3,8 +3,10 @@ package com.umc.EveryWear;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class EveryWearApplication {
 

--- a/src/main/java/com/umc/EveryWear/domain/product/service/scheduler/ProductCleanupScheduler.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/scheduler/ProductCleanupScheduler.java
@@ -1,0 +1,51 @@
+package com.umc.EveryWear.domain.product.service.scheduler;
+
+import com.umc.EveryWear.domain.user.entity.mapping.UserProduct;
+import com.umc.EveryWear.domain.user.repository.UserProductRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+// 60일 경과된 UserProduct를 자동으로 삭제하는 스케줄러
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductCleanupScheduler {
+
+    private final UserProductRepository userProductRepository;
+    
+    private static final int EXPIRATION_DAYS = 60;
+
+    // 매일 자정(00:00:00)에 실행되어 60일 경과된 UserProduct를 삭제
+    // cron 표현식: 초 분 시 일 월 요일
+    // "0 10 16 * * ?" = 매일 16:10:00에 실행
+    // "0 * * * * ?" = 테스트용(1분마다 실행)
+    @Scheduled(cron = "0 0 0 * * ?")
+    @Transactional
+    public void deleteExpiredUserProducts() {
+        try {
+            LocalDateTime cutoffDate = LocalDateTime.now().minusDays(EXPIRATION_DAYS);
+            log.info("60일 경과된 UserProduct 삭제 작업 시작. 기준 날짜: {}", cutoffDate);
+            
+            List<UserProduct> expiredProducts = userProductRepository.findExpiredUserProducts(cutoffDate);
+            
+            if (expiredProducts.isEmpty()) {
+                log.info("삭제할 만료된 UserProduct가 없습니다.");
+                return;
+            }
+            
+            int deletedCount = expiredProducts.size();
+            userProductRepository.deleteAll(expiredProducts);
+            
+            log.info("60일 경과된 UserProduct {}개 삭제 완료", deletedCount);
+            
+        } catch (Exception e) {
+            log.error("60일 경과된 UserProduct 삭제 중 오류 발생: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/umc/EveryWear/domain/user/repository/UserProductRepository.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/repository/UserProductRepository.java
@@ -34,4 +34,8 @@ public interface UserProductRepository extends JpaRepository<UserProduct, Long> 
     @Modifying
     @Query("UPDATE UserProduct up SET up.updatedAt = :updatedAt WHERE up.user.userId = :userId AND up.product.productId = :productId")
     void updateUpdatedAt(@Param("userId") Long userId, @Param("productId") Long productId, @Param("updatedAt") LocalDateTime updatedAt);
+    
+    // 60일 경과된 UserProduct 조회
+    @Query("SELECT up FROM UserProduct up WHERE up.updatedAt < :cutoffDate")
+    List<UserProduct> findExpiredUserProducts(@Param("cutoffDate") LocalDateTime cutoffDate);
 }


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #52 

## ✨ 작업 개요
> 스케쥴러(@Scheduled)를 이용하여 매일 자정(00:00:00)에 update_at 을 기준으로 60일이 경과한 상품을 삭제하는 기능을 구현했습니다.
상품 삭제 실행 간격과 경과일 수는 조정 가능합니다.

## 📷 이미지 첨부 (선택)
- 삭제할 상품이 있을 때
<img width="1643" height="52" alt="image" src="https://github.com/user-attachments/assets/e293fd0f-1f60-4a35-955b-456461590e94" />
- 삭제할 상품이 없을 때
<img width="1642" height="46" alt="image" src="https://github.com/user-attachments/assets/6fbd1124-89bf-4b89-8b98-55b52c9994cc" />


## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.