### PR TITLE
[Feat] 상품 좋아요 API 구현 및 응답 필드 추가

### DIFF
--- a/src/main/java/com/umc/EveryWear/domain/home/converter/HomeConverter.java
+++ b/src/main/java/com/umc/EveryWear/domain/home/converter/HomeConverter.java
@@ -2,10 +2,11 @@ package com.umc.EveryWear.domain.home.converter;
 
 import com.umc.EveryWear.domain.home.dto.res.HomeResDTO;
 import com.umc.EveryWear.domain.product.entity.Product;
+import com.umc.EveryWear.domain.user.entity.mapping.UserProduct;
 
 public class HomeConverter {
 
-    // Product Entity -> Home ProductDTO
+    // Product Entity -> Home ProductDTO (fallback)
     public static HomeResDTO.ProductDTO toProductDTO(Product product) {
         return HomeResDTO.ProductDTO.builder()
                 .product_id(product.getProductId())
@@ -19,6 +20,26 @@ public class HomeConverter {
                 .star_point(product.getStarPoint())
                 .AI_review(product.getAiReview())
                 .product_num(product.getProductNum())
+                .is_liked(false) // Product만 있는 경우 기본값
+                .build();
+    }
+
+    // UserProduct Entity -> Home ProductDTO (실제 is_liked 사용)
+    public static HomeResDTO.ProductDTO toProductDTO(UserProduct userProduct) {
+        Product product = userProduct.getProduct();
+        return HomeResDTO.ProductDTO.builder()
+                .product_id(product.getProductId())
+                .shoppingmale_name(product.getShoppingmallName())
+                .product_url(product.getProductUrl())
+                .category(product.getCategory())
+                .product_img_url(product.getProductImgUrl())
+                .product_name(product.getProductName())
+                .brand_name(product.getBrandName())
+                .price(product.getPrice())
+                .star_point(product.getStarPoint())
+                .AI_review(product.getAiReview())
+                .product_num(product.getProductNum())
+                .is_liked(userProduct.getIsLiked())
                 .build();
     }
 }

--- a/src/main/java/com/umc/EveryWear/domain/home/dto/res/HomeResDTO.java
+++ b/src/main/java/com/umc/EveryWear/domain/home/dto/res/HomeResDTO.java
@@ -19,6 +19,7 @@ public class HomeResDTO {
         private Float star_point;
         private String AI_review;
         private Long product_num;
+        private Boolean is_liked;
     }
 
     @Getter

--- a/src/main/java/com/umc/EveryWear/domain/home/service/query/HomeQueryServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/home/service/query/HomeQueryServiceImpl.java
@@ -26,7 +26,7 @@ public class HomeQueryServiceImpl implements HomeQueryService {
         List<UserProduct> userProducts = userProductRepository.findTop6ProductsByUserIdOrderByUpdatedAtDesc(userId, pageable);
         
         List<HomeResDTO.ProductDTO> productList = userProducts.stream()
-                .map(userProduct -> HomeConverter.toProductDTO(userProduct.getProduct()))
+                .map(userProduct -> HomeConverter.toProductDTO(userProduct))
                 .collect(Collectors.toList());
 
         return HomeResDTO.ProductListResponse.builder()

--- a/src/main/java/com/umc/EveryWear/domain/home/service/query/HomeQueryServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/home/service/query/HomeQueryServiceImpl.java
@@ -2,7 +2,7 @@ package com.umc.EveryWear.domain.home.service.query;
 
 import com.umc.EveryWear.domain.home.converter.HomeConverter;
 import com.umc.EveryWear.domain.home.dto.res.HomeResDTO;
-import com.umc.EveryWear.domain.product.entity.Product;
+import com.umc.EveryWear.domain.user.entity.mapping.UserProduct;
 import com.umc.EveryWear.domain.user.repository.UserProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -23,10 +23,10 @@ public class HomeQueryServiceImpl implements HomeQueryService {
     @Override
     public HomeResDTO.ProductListResponse getHomeProducts(Long userId) {
         Pageable pageable = PageRequest.of(0, 6);
-        List<Product> products = userProductRepository.findTop6ProductsByUserIdOrderByUpdatedAtDesc(userId, pageable);
+        List<UserProduct> userProducts = userProductRepository.findTop6ProductsByUserIdOrderByUpdatedAtDesc(userId, pageable);
         
-        List<HomeResDTO.ProductDTO> productList = products.stream()
-                .map(HomeConverter::toProductDTO)
+        List<HomeResDTO.ProductDTO> productList = userProducts.stream()
+                .map(userProduct -> HomeConverter.toProductDTO(userProduct.getProduct()))
                 .collect(Collectors.toList());
 
         return HomeResDTO.ProductListResponse.builder()

--- a/src/main/java/com/umc/EveryWear/domain/product/controller/ProductController.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/controller/ProductController.java
@@ -11,11 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Product", description = "상품 관련 API")
 @RestController
@@ -204,5 +200,23 @@ public class ProductController {
             successCode = ProductSuccessCode.CM29_PRODUCT_ADDED;
         }
         return ApiResponse.onSuccess(successCode, response);
+    }
+
+    @Operation(
+            summary = "상품 좋아요 토글",
+            description = "특정 상품에 대한 사용자의 좋아요 상태를 토글합니다. 호출할 때마다 true/false가 반전됩니다."
+    )
+    @PatchMapping("/products/{product_id}/like")
+    public ApiResponse<ProductResDTO.LikeToggleDTO> toggleProductLike(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable("product_id") Long productId
+    ) {
+        ProductResDTO.LikeToggleDTO result = productCommandService.toggleProductLike(userId, productId);
+
+        ProductSuccessCode successCode = Boolean.TRUE.equals(result.getIs_liked())
+                ? ProductSuccessCode.PRODUCT_LIKE_ENABLED
+                : ProductSuccessCode.PRODUCT_LIKE_DISABLED;
+
+        return ApiResponse.onSuccess(successCode, result);
     }
 }

--- a/src/main/java/com/umc/EveryWear/domain/product/converter/ProductConverter.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/converter/ProductConverter.java
@@ -2,6 +2,7 @@ package com.umc.EveryWear.domain.product.converter;
 
 import com.umc.EveryWear.domain.product.dto.res.ProductResDTO;
 import com.umc.EveryWear.domain.product.entity.Product;
+import com.umc.EveryWear.domain.user.entity.mapping.UserProduct;
 
 public class ProductConverter {
 
@@ -35,8 +36,9 @@ public class ProductConverter {
                 .build();
     }
 
-    // Entity -> DTO (상품 조회 응답)
-    public static ProductResDTO.ListDTO toListDTO(Product product) {
+    // Entity -> DTO (상품 조회 응답) - UserProduct 기반
+    public static ProductResDTO.ListDTO toListDTO(UserProduct userProduct) {
+        Product product = userProduct.getProduct();
         return ProductResDTO.ListDTO.builder()
                 .product_id(product.getProductId())
                 .shoppingmale_name(product.getShoppingmallName())
@@ -49,6 +51,7 @@ public class ProductConverter {
                 .star_point(product.getStarPoint())
                 .AI_review(product.getAiReview())
                 .product_num(product.getProductNum())
+                .is_liked(userProduct.getIsLiked())
                 .build();
     }
 }

--- a/src/main/java/com/umc/EveryWear/domain/product/converter/ProductConverter.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/converter/ProductConverter.java
@@ -6,17 +6,17 @@ import com.umc.EveryWear.domain.user.entity.mapping.UserProduct;
 
 public class ProductConverter {
 
-    // Entity -> DTO (상품 등록 응답)
+    // Entity -> DTO (신규 상품 등록 응답)
     public static ProductResDTO.ImportDTO toImportDTO(Product product) {
         return toImportDTO(product, false);
     }
 
-    // Entity -> DTO (상품 등록 응답, 업데이트 여부 포함)
+    // Entity -> DTO (신규 상품 등록 응답, 업데이트 여부 포함)
     public static ProductResDTO.ImportDTO toImportDTO(Product product, boolean isUpdated) {
         return toImportDTO(product, isUpdated, false);
     }
 
-    // Entity -> DTO (상품 등록 응답, 업데이트 여부 및 URL 업데이트 여부 포함)
+    // Entity -> DTO (신규 상품 등록 응답, 업데이트 여부 및 URL 업데이트 여부 포함)
     public static ProductResDTO.ImportDTO toImportDTO(Product product, boolean isUpdated, boolean isUrlUpdated) {
         return ProductResDTO.ImportDTO.builder()
                 .product_id(product.getProductId())
@@ -30,7 +30,38 @@ public class ProductConverter {
                 .star_point(product.getStarPoint())
                 .AI_review(product.getAiReview())
                 .product_num(product.getProductNum())
-                .is_liked(false)
+                .is_liked(false) // Product만 있는 컨텍스트에서는 is_liked를 알 수 없으므로 기본값
+                .isUpdated(isUpdated)
+                .isUrlUpdated(isUrlUpdated)
+                .build();
+    }
+
+    // Entity -> DTO (상품 재등록 응답)
+    public static ProductResDTO.ImportDTO toImportDTO(UserProduct userProduct) {
+        return toImportDTO(userProduct, false, false);
+    }
+
+    // Entity -> DTO (상품 재등록 응답, 업데이트 여부 포함)
+    public static ProductResDTO.ImportDTO toImportDTO(UserProduct userProduct, boolean isUpdated) {
+        return toImportDTO(userProduct, isUpdated, false);
+    }
+
+    // Entity -> DTO (상품 재등록 응답, 업데이트 여부 및 URL 업데이트 여부 포함)
+    public static ProductResDTO.ImportDTO toImportDTO(UserProduct userProduct, boolean isUpdated, boolean isUrlUpdated) {
+        Product product = userProduct.getProduct();
+        return ProductResDTO.ImportDTO.builder()
+                .product_id(product.getProductId())
+                .shoppingmale_name(product.getShoppingmallName())
+                .product_url(product.getProductUrl())
+                .category(product.getCategory())
+                .product_img_url(product.getProductImgUrl())
+                .product_name(product.getProductName())
+                .brand_name(product.getBrandName())
+                .price(product.getPrice())
+                .star_point(product.getStarPoint())
+                .AI_review(product.getAiReview())
+                .product_num(product.getProductNum())
+                .is_liked(userProduct.getIsLiked())
                 .isUpdated(isUpdated)
                 .isUrlUpdated(isUrlUpdated)
                 .build();

--- a/src/main/java/com/umc/EveryWear/domain/product/converter/ProductConverter.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/converter/ProductConverter.java
@@ -29,6 +29,7 @@ public class ProductConverter {
                 .star_point(product.getStarPoint())
                 .AI_review(product.getAiReview())
                 .product_num(product.getProductNum())
+                .is_liked(false)
                 .isUpdated(isUpdated)
                 .isUrlUpdated(isUrlUpdated)
                 .build();

--- a/src/main/java/com/umc/EveryWear/domain/product/dto/res/ProductResDTO.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/dto/res/ProductResDTO.java
@@ -20,6 +20,7 @@ public class ProductResDTO {
         private Float star_point;
         private String AI_review;
         private Long product_num;
+        private Boolean is_liked;
 
         // 업데이트 여부 및 URL 업데이트 여부는 응답 포함X
         @JsonIgnore

--- a/src/main/java/com/umc/EveryWear/domain/product/dto/res/ProductResDTO.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/dto/res/ProductResDTO.java
@@ -43,6 +43,7 @@ public class ProductResDTO {
         private Float star_point;
         private String AI_review;
         private Long product_num;
+        private Boolean is_liked;
     }
 
     @Getter

--- a/src/main/java/com/umc/EveryWear/domain/product/dto/res/ProductResDTO.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/dto/res/ProductResDTO.java
@@ -31,6 +31,12 @@ public class ProductResDTO {
 
     @Getter
     @Builder
+    public static class LikeToggleDTO {
+        private Boolean is_liked;
+    }
+
+    @Getter
+    @Builder
     public static class ListDTO {
         private Long product_id;
         private String shoppingmale_name;

--- a/src/main/java/com/umc/EveryWear/domain/product/entity/Product.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/entity/Product.java
@@ -1,5 +1,6 @@
 package com.umc.EveryWear.domain.product.entity;
 
+import com.umc.EveryWear.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -9,7 +10,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Product {
+public class Product extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/umc/EveryWear/domain/product/exception/code/ProductErrorCode.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/exception/code/ProductErrorCode.java
@@ -15,6 +15,9 @@ public enum ProductErrorCode implements BaseErrorCode {
     INVALID_URL_FORMAT(HttpStatus.BAD_REQUEST,
             "400",
             "지원되지 않는 url 형식입니다."),
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND,
+            "404",
+            "수정하려는 상품을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/umc/EveryWear/domain/product/exception/code/ProductSuccessCode.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/exception/code/ProductSuccessCode.java
@@ -63,6 +63,12 @@ public enum ProductSuccessCode implements BaseSuccessCode {
     ETC_PRODUCTS_RETRIEVED(HttpStatus.OK,
             "200",
             "기타 상품을 조회했습니다."),
+    PRODUCT_LIKE_ENABLED(HttpStatus.OK,
+            "200",
+            "상품 좋아요가 성공적으로 활성화되었습니다."),
+    PRODUCT_LIKE_DISABLED(HttpStatus.OK,
+            "200",
+            "상품 좋아요가 성공적으로 비활성화되었습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandService.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandService.java
@@ -8,4 +8,5 @@ public interface ProductCommandService {
     ProductResDTO.ImportDTO importZigzagProduct(Long userId, ProductReqDTO.ImportZigzagDTO dto);
     ProductResDTO.ImportDTO importWconceptProduct(Long userId, ProductReqDTO.WconceptImportDTO dto);
     ProductResDTO.ImportDTO import29cmProduct(Long userId, ProductReqDTO.Import29cmDTO dto);
+    ProductResDTO.LikeToggleDTO toggleProductLike(Long userId, Long productId);
 }

--- a/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
@@ -77,12 +77,15 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                             .user(user)
                             .product(existingProductByUrl)
                             .build();
-                    userProductRepository.save(userProduct);
+                    UserProduct savedUserProduct = userProductRepository.save(userProduct);
+                    // 새로 등록한 경우 is_liked는 기본 false
+                    return ProductConverter.toImportDTO(savedUserProduct, true);
                 } else {
                     // 기존 UserProduct가 있으면 updated_at을 현재 시간으로 업데이트
                     userProductRepository.updateUpdatedAt(userId, existingProductByUrl.getProductId(), LocalDateTime.now());
+                    // 이전에 사용하던 is_liked 값을 그대로 응답
+                    return ProductConverter.toImportDTO(existingUserProduct, true);
                 }
-                return ProductConverter.toImportDTO(existingProductByUrl, true);
             }
 
             // 크롤링 실행
@@ -110,12 +113,14 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                             .user(user)
                             .product(updatedProduct)
                             .build();
-                    userProductRepository.save(userProduct);
+                    UserProduct savedUserProduct = userProductRepository.save(userProduct);
+                    // 새 매핑이므로 is_liked 기본 false
+                    return ProductConverter.toImportDTO(savedUserProduct, true, true);
                 } else {
-                    // 기존 UserProduct가 있으면 updated_at을 현재 시간으로 업데이트
+                    // 기존 UserProduct가 있으면 updated_at만 갱신하고, is_liked는 이전 값 유지
                     userProductRepository.updateUpdatedAt(userId, updatedProduct.getProductId(), LocalDateTime.now());
+                    return ProductConverter.toImportDTO(existingUserProduct, true, true);
                 }
-                return ProductConverter.toImportDTO(updatedProduct, true, true);
             }
 
             // Product 엔터티 생성 및 저장 (전역)
@@ -134,14 +139,14 @@ public class ProductCommandServiceImpl implements ProductCommandService {
 
             Product savedProduct = productRepository.save(product);
             
-            // UserProduct에 저장
+            // UserProduct에 저장 (신규 등록이므로 is_liked는 기본 false)
             UserProduct userProduct = UserProduct.builder()
                     .user(user)
                     .product(savedProduct)
                     .build();
-            userProductRepository.save(userProduct);
+            UserProduct savedUserProduct = userProductRepository.save(userProduct);
 
-            return ProductConverter.toImportDTO(savedProduct);
+            return ProductConverter.toImportDTO(savedUserProduct);
 
         } catch (Exception e) {
             log.error("무신사 상품 크롤링 중 오류 발생: {}", e.getMessage(), e);
@@ -303,12 +308,13 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                             .user(user)
                             .product(existingProductByUrl)
                             .build();
-                    userProductRepository.save(userProduct);
+                    UserProduct savedUserProduct = userProductRepository.save(userProduct);
+                    return ProductConverter.toImportDTO(savedUserProduct, true);
                 } else {
-                    // 기존 UserProduct가 있으면 updated_at을 현재 시간으로 업데이트
+                    // 기존 UserProduct가 있으면 updated_at을 현재 시간으로 업데이트만 수행
                     userProductRepository.updateUpdatedAt(userId, existingProductByUrl.getProductId(), LocalDateTime.now());
+                    return ProductConverter.toImportDTO(existingUserProduct, true);
                 }
-                return ProductConverter.toImportDTO(existingProductByUrl, true);
             }
 
             // 크롤링 실행
@@ -336,12 +342,13 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                             .user(user)
                             .product(updatedProduct)
                             .build();
-                    userProductRepository.save(userProduct);
+                    UserProduct savedUserProduct = userProductRepository.save(userProduct);
+                    return ProductConverter.toImportDTO(savedUserProduct, true, true);
                 } else {
-                    // 기존 UserProduct가 있으면 updated_at을 현재 시간으로 업데이트
+                    // 기존 UserProduct가 있으면 updated_at만 갱신하고, is_liked는 이전 값 유지
                     userProductRepository.updateUpdatedAt(userId, updatedProduct.getProductId(), LocalDateTime.now());
+                    return ProductConverter.toImportDTO(existingUserProduct, true, true);
                 }
-                return ProductConverter.toImportDTO(updatedProduct, true, true);
             }
 
             // Product 엔터티 생성 및 저장 (전역)
@@ -360,14 +367,14 @@ public class ProductCommandServiceImpl implements ProductCommandService {
 
             Product savedProduct = productRepository.save(product);
             
-            // UserProduct에 저장
+            // UserProduct에 저장 (신규 등록이므로 is_liked는 기본 false)
             UserProduct userProduct = UserProduct.builder()
                     .user(user)
                     .product(savedProduct)
                     .build();
-            userProductRepository.save(userProduct);
+            UserProduct savedUserProduct = userProductRepository.save(userProduct);
 
-            return ProductConverter.toImportDTO(savedProduct);
+            return ProductConverter.toImportDTO(savedUserProduct);
 
         } catch (Exception e) {
             log.error("지그재그 상품 크롤링 중 오류 발생: {}", e.getMessage(), e);
@@ -502,12 +509,13 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                             .user(user)
                             .product(existingProductByUrl)
                             .build();
-                    userProductRepository.save(userProduct);
+                    UserProduct savedUserProduct = userProductRepository.save(userProduct);
+                    return ProductConverter.toImportDTO(savedUserProduct, true);
                 } else {
-                    // 기존 UserProduct가 있으면 updated_at을 현재 시간으로 업데이트
+                    // 기존 UserProduct가 있으면 updated_at을 현재 시간으로 업데이트만 수행
                     userProductRepository.updateUpdatedAt(userId, existingProductByUrl.getProductId(), LocalDateTime.now());
+                    return ProductConverter.toImportDTO(existingUserProduct, true);
                 }
-                return ProductConverter.toImportDTO(existingProductByUrl, true);
             }
 
             // 크롤링 실행
@@ -535,12 +543,13 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                             .user(user)
                             .product(updatedProduct)
                             .build();
-                    userProductRepository.save(userProduct);
+                    UserProduct savedUserProduct = userProductRepository.save(userProduct);
+                    return ProductConverter.toImportDTO(savedUserProduct, true, true);
                 } else {
-                    // 기존 UserProduct가 있으면 updated_at을 현재 시간으로 업데이트
+                    // 기존 UserProduct가 있으면 updated_at만 갱신하고, is_liked는 이전 값 유지
                     userProductRepository.updateUpdatedAt(userId, updatedProduct.getProductId(), LocalDateTime.now());
+                    return ProductConverter.toImportDTO(existingUserProduct, true, true);
                 }
-                return ProductConverter.toImportDTO(updatedProduct, true, true);
             }
 
             // Product 엔터티 생성 및 저장 (전역)
@@ -559,14 +568,14 @@ public class ProductCommandServiceImpl implements ProductCommandService {
 
             Product savedProduct = productRepository.save(product);
             
-            // UserProduct에 저장
+            // UserProduct에 저장 (신규 등록이므로 is_liked는 기본 false)
             UserProduct userProduct = UserProduct.builder()
                     .user(user)
                     .product(savedProduct)
                     .build();
-            userProductRepository.save(userProduct);
+            UserProduct savedUserProduct = userProductRepository.save(userProduct);
 
-            return ProductConverter.toImportDTO(savedProduct);
+            return ProductConverter.toImportDTO(savedUserProduct);
 
         } catch (Exception e) {
             log.error("29cm 상품 크롤링 중 오류 발생: {}", e.getMessage(), e);

--- a/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
@@ -148,6 +148,39 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             throw new ProductException(ProductErrorCode.CRAWLING_FAILED);
         }
     }
+
+    @Override
+    public ProductResDTO.LikeToggleDTO toggleProductLike(Long userId, Long productId) {
+        // 상품 존재 여부 검증
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        // User 조회 (매핑이 새로 생길 수도 있으므로)
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ProductException(ProductErrorCode.CRAWLING_FAILED));
+
+        // 해당 사용자의 UserProduct 조회
+        UserProduct userProduct = userProductRepository
+                .findByUser_UserIdAndProduct_ProductId(userId, productId)
+                .orElseGet(() -> {
+                    // 매핑이 없으면 새로 생성 (기본 isLiked=false)
+                    UserProduct up = UserProduct.builder()
+                            .user(user)
+                            .product(product)
+                            .build();
+                    return userProductRepository.save(up);
+                });
+
+        // 좋아요 상태 토글
+        userProduct.toggleLike();
+
+        // JPA 변경 감지로 업데이트, 혹시 모르니 save 호출
+        UserProduct saved = userProductRepository.save(userProduct);
+
+        return ProductResDTO.LikeToggleDTO.builder()
+                .is_liked(saved.getIsLiked())
+                .build();
+    }
   
     // 무신사 상품 정보 크롤링 - FastAPI 서버 호출
     private ProductCrawlingData crawlMusinsaProduct(String url) {

--- a/src/main/java/com/umc/EveryWear/domain/product/service/query/ProductQueryServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/query/ProductQueryServiceImpl.java
@@ -2,7 +2,7 @@ package com.umc.EveryWear.domain.product.service.query;
 
 import com.umc.EveryWear.domain.product.converter.ProductConverter;
 import com.umc.EveryWear.domain.product.dto.res.ProductResDTO;
-import com.umc.EveryWear.domain.product.entity.Product;
+import com.umc.EveryWear.domain.user.entity.mapping.UserProduct;
 import com.umc.EveryWear.domain.user.repository.UserProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,9 +20,9 @@ public class ProductQueryServiceImpl implements ProductQueryService {
 
     @Override
     public ProductResDTO.ProductListResponse getAllProductsByUserId(Long userId) {
-        List<Product> products = userProductRepository.findAllProductsByUserIdOrderByUpdatedAtDesc(userId);
+        List<UserProduct> userProducts = userProductRepository.findAllProductsByUserIdOrderByUpdatedAtDesc(userId);
         
-        List<ProductResDTO.ListDTO> productList = products.stream()
+        List<ProductResDTO.ListDTO> productList = userProducts.stream()
                 .map(ProductConverter::toListDTO)
                 .collect(Collectors.toList());
 
@@ -33,9 +33,9 @@ public class ProductQueryServiceImpl implements ProductQueryService {
 
     @Override
     public ProductResDTO.ProductListResponse getProductsByCategory(Long userId, String category) {
-        List<Product> products = userProductRepository.findProductsByUserIdAndCategoryOrderByUpdatedAtDesc(userId, category);
+        List<UserProduct> userProducts = userProductRepository.findProductsByUserIdAndCategoryOrderByUpdatedAtDesc(userId, category);
         
-        List<ProductResDTO.ListDTO> productList = products.stream()
+        List<ProductResDTO.ListDTO> productList = userProducts.stream()
                 .map(ProductConverter::toListDTO)
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/umc/EveryWear/domain/user/entity/mapping/UserProduct.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/entity/mapping/UserProduct.java
@@ -38,5 +38,9 @@ public class UserProduct extends BaseEntity {
     @OneToMany(mappedBy = "userProduct", cascade = CascadeType.ALL)
     @Builder.Default
     private List<FittingHistory> fittingHistories = new ArrayList<>();
+
+    public void toggleLike() {
+        this.isLiked = !Boolean.TRUE.equals(this.isLiked);
+    }
 }
 

--- a/src/main/java/com/umc/EveryWear/domain/user/repository/UserProductRepository.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/repository/UserProductRepository.java
@@ -16,16 +16,16 @@ import java.util.Optional;
 public interface UserProductRepository extends JpaRepository<UserProduct, Long> {
     
     // 사용자별 상품 조회 (updatedAt 내림차순)
-    @Query("SELECT up.product FROM UserProduct up WHERE up.user.userId = :userId ORDER BY up.updatedAt DESC")
-    List<com.umc.EveryWear.domain.product.entity.Product> findAllProductsByUserIdOrderByUpdatedAtDesc(@Param("userId") Long userId);
+    @Query("SELECT up FROM UserProduct up WHERE up.user.userId = :userId ORDER BY up.updatedAt DESC")
+    List<UserProduct> findAllProductsByUserIdOrderByUpdatedAtDesc(@Param("userId") Long userId);
     
     // 사용자별 카테고리별 상품 조회 (updatedAt 내림차순)
-    @Query("SELECT up.product FROM UserProduct up WHERE up.user.userId = :userId AND up.product.category = :category ORDER BY up.updatedAt DESC")
-    List<com.umc.EveryWear.domain.product.entity.Product> findProductsByUserIdAndCategoryOrderByUpdatedAtDesc(@Param("userId") Long userId, @Param("category") String category);
+    @Query("SELECT up FROM UserProduct up WHERE up.user.userId = :userId AND up.product.category = :category ORDER BY up.updatedAt DESC")
+    List<UserProduct> findProductsByUserIdAndCategoryOrderByUpdatedAtDesc(@Param("userId") Long userId, @Param("category") String category);
     
     // 사용자별 상품 조회 상위 6개 (updatedAt 내림차순)
-    @Query("SELECT up.product FROM UserProduct up WHERE up.user.userId = :userId ORDER BY up.updatedAt DESC")
-    List<com.umc.EveryWear.domain.product.entity.Product> findTop6ProductsByUserIdOrderByUpdatedAtDesc(@Param("userId") Long userId, Pageable pageable);
+    @Query("SELECT up FROM UserProduct up WHERE up.user.userId = :userId ORDER BY up.updatedAt DESC")
+    List<UserProduct> findTop6ProductsByUserIdOrderByUpdatedAtDesc(@Param("userId") Long userId, Pageable pageable);
     
     // 특정 사용자와 상품으로 UserProduct 조회
     Optional<UserProduct> findByUser_UserIdAndProduct_ProductId(Long userId, Long productId);


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #53
- resolve #57 

## ✨ 작업 개요
> 상품 좋아요 API를 구현하고, 홈 화면 조회, 상품 목록 조회, 상품 등록 응답에 좋아요(is_liked) 필드를 추가합니다.

## 📷 이미지 첨부 (선택)
- 좋아요 API
<img width="1767" height="866" alt="image" src="https://github.com/user-attachments/assets/b2df6ac8-df26-4cdc-a257-1dc56e063726" />
<img width="1768" height="893" alt="image" src="https://github.com/user-attachments/assets/b8f0afda-69d4-4c48-93f1-0db1da8a35bc" />

- 상품 등록 응답에 좋아요 필드 추가
<img width="1752" height="806" alt="image" src="https://github.com/user-attachments/assets/b89907a9-893d-4a26-baa4-9d095a73b307" />

- 상품 조회 응답에 좋아요 필드 추가
<img width="1756" height="890" alt="image" src="https://github.com/user-attachments/assets/ec09694f-ea8a-4155-b29c-2520f47a59fb" />


## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.