### PR TITLE
[Feat] 유저 프로필 이미지 조회, 삭제 기능 구현

### DIFF
--- a/src/main/java/com/umc/EveryWear/domain/user/controller/UserImgController.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/controller/UserImgController.java
@@ -1,10 +1,12 @@
 package com.umc.EveryWear.domain.user.controller;
 
+import com.umc.EveryWear.domain.user.dto.res.UserImgResponseDto;
 import com.umc.EveryWear.domain.user.entity.User;
 import com.umc.EveryWear.domain.user.exception.UserImgException;
 import com.umc.EveryWear.domain.user.exception.code.UserImgErrorCode;
 import com.umc.EveryWear.domain.user.exception.code.UserImgSuccessCode;
 import com.umc.EveryWear.domain.user.service.command.UserImgCommandService;
+import com.umc.EveryWear.domain.user.service.query.UserImgQueryService;
 import com.umc.EveryWear.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -13,12 +15,15 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/user-images")
 @RequiredArgsConstructor
 public class UserImgController {
 
     private final UserImgCommandService userImgCommandService;
+    private final UserImgQueryService userImgQueryService;
 
     /**
      * 사용자 이미지 검증 및 저장 API
@@ -69,5 +74,34 @@ public class UserImgController {
                 UserImgSuccessCode.REPRESENTATIVE_IMAGE_UPDATED,
                 null
         );
+    }
+
+    /**
+     * 프로필 이미지 목록 조회
+     */
+    @Operation(
+            summary = "프로필 사진 조회 by 임준서(개발 완료)",
+            description = "사용자의 모든 프로필사진들을 조회합니다."
+    )
+    @GetMapping
+    public List<UserImgResponseDto.UserImgQuery> getProfileImages(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return userImgQueryService.getProfileImages(userId);
+    }
+
+    /**
+     * 프로필 이미지 삭제
+     */
+    @Operation(
+            summary = "프로필 사진 삭제 by 임준서(개발 완료)",
+            description = "사용자가 선택한 프로필사진을 삭제합니다."
+    )
+    @DeleteMapping("/{imageId}")
+    public void deleteProfileImage(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long imageId
+    ) {
+        userImgCommandService.deleteProfileImage(userId, imageId);
     }
 }

--- a/src/main/java/com/umc/EveryWear/domain/user/exception/code/UserImgErrorCode.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/exception/code/UserImgErrorCode.java
@@ -12,38 +12,40 @@ public enum UserImgErrorCode implements BaseErrorCode {
     IMAGE_READ_FAILED(
             HttpStatus.BAD_REQUEST,
             "USERIMG400_1",
-            "이미지 파일을 읽는 데 실패했습니다."
-    ),
-
+            "이미지 파일을 읽는 데 실패했습니다."),
     INVALID_USER_IMAGE(
             HttpStatus.BAD_REQUEST,
             "USERIMG400_2",
-            "피팅에 적합하지 않은 이미지입니다."
-    ),
+            "피팅에 적합하지 않은 이미지입니다."),
+    IMAGE_LIMIT_EXCEEDED(
+            HttpStatus.BAD_REQUEST,
+            "USERIMG400_3",
+            "저장 가능한 이미지 개수를 초과했습니다."),
+    USER_IMAGE_LIMIT_EXCEEDED(
+            HttpStatus.BAD_REQUEST,
+            "USERIMG400_4",
+            "저장 가능 최대 대표사진 수는 5장 입니다."),
+    USER_REPRESENTATIVE_IMG_CANNOT_DELETE(
+            HttpStatus.BAD_REQUEST,
+            "USERIMG_400_5",
+            "대표 사진은 삭제할 수 없습니다."),
 
     USER_IMAGE_NOT_FOUND(
             HttpStatus.NOT_FOUND,
             "USERIMG404_1",
-            "사용자 이미지를 찾을 수 없습니다."
-    ),
+            "사용자 이미지를 찾을 수 없습니다."),
 
-    IMAGE_LIMIT_EXCEEDED(
-            HttpStatus.BAD_REQUEST,
-            "USERIMG400_3",
-            "저장 가능한 이미지 개수를 초과했습니다."
-    ),
     INTERNAL_ERROR(
             HttpStatus.INTERNAL_SERVER_ERROR,
             "USERIMG500_1",
-            "사용자 이미지 처리 중 서버 오류가 발생했습니다."
-    ), USER_IMAGE_LIMIT_EXCEEDED(
-            HttpStatus.BAD_REQUEST,
-            "USERIMG400_4",
-            "저장 가능 최대 대표사진 수는 5장 입니다."),
+            "사용자 이미지 처리 중 서버 오류가 발생했습니다."),
+
+
     REPRESENTATIVE_IMAGE_NOT_FOUND(
             HttpStatus.NOT_FOUND,
             "USERIMG404_2",
             "사용자 대표 사진을 찾을 수 없습니다."),
+
     USER_NOT_FOUND(
             HttpStatus.NOT_FOUND,
             "USERIMG404_3",

--- a/src/main/java/com/umc/EveryWear/domain/user/repository/UserImgRepository.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/repository/UserImgRepository.java
@@ -17,5 +17,5 @@ public interface UserImgRepository extends JpaRepository<UserImg, Long> {
 
     Optional<UserImg> findByUserAndRepresentativeTrue(User user);
 
-    List<UserImg> findAllByUser(User user);
+    Optional<UserImg> findByUser_UserIdAndProfileImageId(Long userId, Long imageId);
 }

--- a/src/main/java/com/umc/EveryWear/domain/user/service/command/UserImgCommandService.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/service/command/UserImgCommandService.java
@@ -9,6 +9,7 @@ import com.umc.EveryWear.domain.user.exception.UserImgException;
 import com.umc.EveryWear.domain.user.exception.code.UserImgErrorCode;
 import com.umc.EveryWear.domain.user.repository.UserImgRepository;
 import com.umc.EveryWear.domain.user.repository.UserRepository;
+import com.umc.EveryWear.global.s3.S3ImageDeleter;
 import com.umc.EveryWear.global.s3.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,6 +26,7 @@ public class UserImgCommandService {
     private final UserImgRepository userImgRepository;
     private final S3Uploader s3Uploader;
     private final UserRepository userRepository;
+    private final S3ImageDeleter s3ImageDeleter;
 
     /**
      * 사용자 이미지 검증 후 저장
@@ -104,5 +106,26 @@ public class UserImgCommandService {
 
         // 3. 새 대표 이미지 지정
         targetImg.makeRepresentative();
+    }
+
+    /**
+     * 유저 프로필 이미지 삭제
+     * - 대표 이미지는 삭제 불가
+     */
+    @Transactional
+    public void deleteProfileImage(Long userId, Long imageId) {
+        UserImg userImg = userImgRepository
+                .findByUser_UserIdAndProfileImageId(userId, imageId)
+                .orElseThrow(() -> new UserImgException(UserImgErrorCode.USER_IMAGE_NOT_FOUND));
+
+        if (userImg.isRepresentative()) {
+            throw new UserImgException(UserImgErrorCode.USER_REPRESENTATIVE_IMG_CANNOT_DELETE);
+        }
+
+        // S3 삭제
+        s3ImageDeleter.deleteByUrl(userImg.getImageUrl());
+
+        // DB 삭제
+        userImgRepository.delete(userImg);
     }
 }

--- a/src/main/java/com/umc/EveryWear/domain/user/service/query/UserImgQueryService.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/service/query/UserImgQueryService.java
@@ -32,12 +32,15 @@ public class UserImgQueryService {
     }
 
     /**
-     * 전체 프로필 이미지 조회
+     * 유저 프로필 이미지 목록 조회
      */
-    public List<UserImgResponseDto.UserImgQuery> getAll(User user) {
-        return userImgRepository.findAllByUser(user)
-                .stream()
-                .map(UserImgResponseDto.UserImgQuery::from)
+    public List<UserImgResponseDto.UserImgQuery> getProfileImages(Long userId) {
+        return userImgRepository.findAllByUser_UserId(userId).stream()
+                .map(img -> new UserImgResponseDto.UserImgQuery(
+                        img.getProfileImageId(),
+                        img.getImageUrl(),
+                        img.isRepresentative()
+                ))
                 .toList();
     }
 

--- a/src/main/java/com/umc/EveryWear/global/s3/S3ImageDeleter.java
+++ b/src/main/java/com/umc/EveryWear/global/s3/S3ImageDeleter.java
@@ -1,0 +1,36 @@
+package com.umc.EveryWear.global.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+
+@Component
+@RequiredArgsConstructor
+public class S3ImageDeleter {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public void deleteByUrl(String imageUrl) {
+        String key = extractKey(imageUrl);
+
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        s3Client.deleteObject(request);
+    }
+
+    /**
+     * https://bucket-name.s3.ap-northeast-2.amazonaws.com/user/profile/xxx.jpg
+     * ㄴ> user/profile/xxx.jpg
+     */
+    private String extractKey(String imageUrl) {
+        return imageUrl.substring(imageUrl.indexOf(".amazonaws.com/") + 18);
+    }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #72 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.
- 유저 프로필 이미지 조회 및 삭제 기능을 구현했습니다.

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!
- 
<img width="2117" height="772" alt="image" src="https://github.com/user-attachments/assets/c42374d9-4e59-470f-826e-bbb2d084525e" />

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.