### PR TITLE
[Fix] 유저 이미지 저장 시 락 설정 및 검증 프롬프트 완화

### DIFF
--- a/src/main/java/com/umc/EveryWear/domain/fitting/client/GeminiImageClient.java
+++ b/src/main/java/com/umc/EveryWear/domain/fitting/client/GeminiImageClient.java
@@ -37,26 +37,48 @@ public class GeminiImageClient {
      */
     public VerificationResult verifyUserImage(byte[] imageBytes) {
         String systemPrompt = """
-                You are the Nano Banana Image Verification Expert.\s
-                Your role is to analyze a person's photo to determine if it is suitable for a professional-grade Virtual Try-on session.
+                You are the Nano Banana Image Verification Expert.
+                Your task is to evaluate whether a user's photo is GENERALLY SUITABLE for a Virtual Try-on experience.
                 
-                ### ASSESSMENT CRITERIA:
-                1. HUMAN_PRESENCE: Is there exactly one person clearly visible?
-                2. POSE: Is the person standing in a natural, relatively frontal pose? (Avoid extreme angles, sitting, or fetal positions)
-                3. BODY_COMPLETENESS: Are the relevant body parts for clothing (shoulders, torso, waist, legs) visible and not cropped out?
-                4. OBSTRUCTIONS: Are there objects (bags, coats, hands) covering the primary areas where new clothes would be placed?
-                5. LIGHTING: Is the lighting sufficient to distinguish the person from the background?
+                IMPORTANT PHILOSOPHY:
+                - Prioritize usability over visual perfection.
+                - Be tolerant of minor imperfections.
+                - Only reject images that are CLEARLY unusable.
                 
-                IMPORTANT:
-                - Output MUST be a valid JSON object.
-                - Do NOT include markdown, explanations, or extra text.
-                - Do NOT wrap the JSON in ``` blocks.
+                ### ASSESSMENT GUIDELINES:
+                
+                1. HUMAN_PRESENCE
+                - Exactly one main person should be visible.
+                - Minor background people, reflections, or posters are acceptable if they do NOT interfere.
+                
+                2. POSE & ORIENTATION
+                - Natural, casual poses are acceptable.
+                - Slight side angles, small rotations, or relaxed stances are OK.
+                - Sitting or leaning is acceptable IF the torso is visible.
+                - Reject ONLY extreme poses that distort body proportions or hide most of the body.
+                
+                3. BODY VISIBILITY
+                - The torso and shoulders MUST be visible.
+                - Partial cropping of legs or arms is acceptable.
+                - Reject ONLY if the main clothing area cannot be reasonably inferred.
+                
+                4. OBSTRUCTIONS
+                - Small objects (phones, hands, bags) are acceptable.
+                - Reject ONLY if large objects block most of the torso or waist.
+                
+                5. LIGHTING & QUALITY
+                - Normal indoor or outdoor lighting is acceptable.
+                - Reject ONLY if the image is extremely dark, blurry, or low-resolution.
+                
+                ### DECISION RULE:
+                - Set "isSuitable = false" ONLY when the image is clearly unusable.
+                - If the image is usable but imperfect, set "isSuitable = true" with a LOWER confidenceScore.
                 
                 ### OUTPUT FORMAT (JSON ONLY):
                 {
                   "isSuitable": boolean,
                   "confidenceScore": float (0.0 to 1.0),
-                  "errorCode": string (e.g., "POOR_LIGHTING", "BODY_CROPPED", "MULTIPLE_PEOPLE", "INVALID_POSE", "OK"),
+                  "errorCode": string ("OK", "POOR_LIGHTING", "BODY_CROPPED", "MULTIPLE_PEOPLE", "SEVERE_OBSTRUCTION", "LOW_QUALITY"),
                   "reason": "Clear explanation in Korean for the user"
                 }""";
 

--- a/src/main/java/com/umc/EveryWear/domain/user/repository/UserImgRepository.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/repository/UserImgRepository.java
@@ -2,7 +2,11 @@ package com.umc.EveryWear.domain.user.repository;
 
 import com.umc.EveryWear.domain.user.entity.User;
 import com.umc.EveryWear.domain.user.entity.UserImg;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,7 +19,11 @@ public interface UserImgRepository extends JpaRepository<UserImg, Long> {
 
     List<UserImg> findAllByUser_UserId(Long userId);
 
-    Optional<UserImg> findByUserAndRepresentativeTrue(User user);
-
     Optional<UserImg> findByUser_UserIdAndProfileImageId(Long userId, Long imageId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select ui from UserImg ui where ui.user.userId = :userId")
+    List<UserImg> lockAllByUserId(@Param("userId") Long userId);
+
+    boolean existsByUser_UserIdAndRepresentativeTrue(Long userId);
 }

--- a/src/main/java/com/umc/EveryWear/domain/user/service/command/UserImgCommandService.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/service/command/UserImgCommandService.java
@@ -69,11 +69,11 @@ public class UserImgCommandService {
                 "user-profile"
         );
 
+        userImgRepository.lockAllByUserId(userId);
+
         // 4. 대표사진 여부 결정
         boolean hasRepresentative =
-                userImgRepository
-                        .findByUser_UserIdAndRepresentativeTrue(userId)
-                        .isPresent();
+                userImgRepository.existsByUser_UserIdAndRepresentativeTrue(userId);
 
         UserImg userImg = UserImg.builder()
                 .user(user)

--- a/src/main/java/com/umc/EveryWear/domain/user/service/query/UserImgQueryService.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/service/query/UserImgQueryService.java
@@ -1,7 +1,6 @@
 package com.umc.EveryWear.domain.user.service.query;
 
 import com.umc.EveryWear.domain.user.dto.res.UserImgResponseDto;
-import com.umc.EveryWear.domain.user.entity.User;
 import com.umc.EveryWear.domain.user.entity.UserImg;
 import com.umc.EveryWear.domain.user.exception.UserImgException;
 import com.umc.EveryWear.domain.user.exception.code.UserImgErrorCode;
@@ -18,18 +17,6 @@ import java.util.List;
 public class UserImgQueryService {
 
     private final UserImgRepository userImgRepository;
-
-    /**
-     * 대표 이미지 조회
-     */
-    public UserImgResponseDto.UserImgQuery getRepresentative(User user) {
-        UserImg img = userImgRepository
-                .findByUserAndRepresentativeTrue(user)
-                .orElseThrow(() ->
-                        new UserImgException(UserImgErrorCode.REPRESENTATIVE_IMAGE_NOT_FOUND));
-
-        return UserImgResponseDto.UserImgQuery.from(img);
-    }
 
     /**
      * 유저 프로필 이미지 목록 조회


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #78 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.
- 유저가 프로필사진을 등록할 때 여러 요청이 한 번에 들어오면서 대표사진 여부가 1인 사진이 2개 생기는 문제가 있어서 락을 걸어서 해결했습니다.
- 유저가 프로필사진을 등록할 때 프롬프트가 너무 엄격해서 성공률이 낮다고 생각되어 프롬프트를 완화했습니다.

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!

- 사용자 이미지 검증 및 저장
<img width="2137" height="932" alt="image" src="https://github.com/user-attachments/assets/0fa650d1-fcf7-49a9-a260-dc0471e0bf74" />

- 대표 사진 변경
<img width="2128" height="948" alt="image" src="https://github.com/user-attachments/assets/d644db8c-d64a-403e-b00c-65863f8cb3dd" />

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.