### PR TITLE
[Fix] 피팅 등록에 product_id 정보 추가

### DIFF
--- a/src/main/java/com/umc/EveryWear/domain/fitting/controller/FittingController.java
+++ b/src/main/java/com/umc/EveryWear/domain/fitting/controller/FittingController.java
@@ -1,11 +1,9 @@
 package com.umc.EveryWear.domain.fitting.controller;
 
-import com.umc.EveryWear.domain.fitting.dto.req.FittingRequestDto;
 import com.umc.EveryWear.domain.fitting.dto.res.FittingResponseDto;
 import com.umc.EveryWear.domain.fitting.exception.code.FittingSuccessCode;
 import com.umc.EveryWear.domain.fitting.service.command.FittingCommandService;
 import com.umc.EveryWear.domain.fitting.service.query.FittingQueryService;
-import com.umc.EveryWear.domain.user.entity.User;
 import com.umc.EveryWear.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -29,14 +27,14 @@ public class FittingController {
             summary = "가상 피팅 by 임준서(개발 완료)",
             description = "사용자의 대표사진에 상품 사진을 피팅합니다"
     )
-    @PostMapping("/try-on")
+    @PostMapping("/{product_id}/try-on")
     public ApiResponse<FittingResponseDto.FittingApplyResult> requestFitting(
             @AuthenticationPrincipal Long userId,
-            @RequestBody FittingRequestDto.FittingRequest request
+            @PathVariable("product_id") Long productId
     ) {
         FittingResponseDto.FittingApplyResult result = fittingCommandService.requestFitting(
                 userId,
-                request.productId()
+                productId
         );
 
         return ApiResponse.onSuccess(


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #93 

## ✨ 작업 개요
> 상품 클릭 -> 피팅 화면 으로 넘어갈 때 필요한 상품 정보를 product_id 쿼리 파라미터로 넘겨 해결합니다.

## 📷 이미지 첨부 (선택)
<img width="1766" height="892" alt="image" src="https://github.com/user-attachments/assets/e2ca6980-b305-4874-b0b0-8ff58596fd70" />

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.