### PR TITLE
[Feat] productId로 가장 최근 피팅내역 이미지 가져오는 기능 구현

### DIFF
--- a/src/main/java/com/umc/EveryWear/domain/fitting/controller/FittingController.java
+++ b/src/main/java/com/umc/EveryWear/domain/fitting/controller/FittingController.java
@@ -79,4 +79,19 @@ public class FittingController {
                 fittingQueryService.getFittingDetail(userId, fittingId)
         );
     }
+
+    @Operation(
+            summary = "상품별 최근 피팅 조회",
+            description = "특정 상품(productId)에 대해 현재 사용자(userId)의 가장 최근 피팅 1건을 조회합니다."
+    )
+    @GetMapping("/latest")
+    public ApiResponse<FittingResponseDto.FittingApplyResult> getLatestFittingByProduct(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam Long productId
+    ) {
+        return ApiResponse.onSuccess(
+                FittingSuccessCode.FITTING_LATEST_FETCHED,
+                fittingQueryService.getLatestFittingByProduct(userId, productId)
+        );
+    }
 }

--- a/src/main/java/com/umc/EveryWear/domain/fitting/exception/code/FittingErrorCode.java
+++ b/src/main/java/com/umc/EveryWear/domain/fitting/exception/code/FittingErrorCode.java
@@ -87,12 +87,6 @@ public enum FittingErrorCode implements BaseErrorCode {
             "FITTING500_3",
             "가상 피팅 이미지 생성에 실패했습니다."
     ),
-
-    INTERNAL_ERROR(
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            "FITTING500_9",
-            "알 수 없는 오류가 발생했습니다."
-    ),
     AI_RESPONSE_INVALID_FORMAT(
             HttpStatus.INTERNAL_SERVER_ERROR,
             "FITTING500_10",

--- a/src/main/java/com/umc/EveryWear/domain/fitting/exception/code/FittingSuccessCode.java
+++ b/src/main/java/com/umc/EveryWear/domain/fitting/exception/code/FittingSuccessCode.java
@@ -73,7 +73,12 @@ public enum FittingSuccessCode implements BaseSuccessCode {
             "좋아요한 피팅 목록 조회에 성공했습니다."
     ),
 
+    FITTING_LATEST_FETCHED(
+            HttpStatus.OK,
+            "FITTING200_8",
+            "최신 피팅 결과 조회에 성공했습니다.")
     ;
+
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/com/umc/EveryWear/domain/fitting/repository/FittingHistoryRepository.java
+++ b/src/main/java/com/umc/EveryWear/domain/fitting/repository/FittingHistoryRepository.java
@@ -3,6 +3,7 @@ package com.umc.EveryWear.domain.fitting.repository;
 import com.umc.EveryWear.domain.fitting.entity.FittingHistory;
 import com.umc.EveryWear.domain.user.entity.User;
 import com.umc.EveryWear.domain.user.entity.mapping.UserProduct;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -51,4 +52,19 @@ public interface FittingHistoryRepository extends JpaRepository<FittingHistory, 
             Long productId
     );
 
+    // 특정 사용자와 상품에 대한 최신 피팅내역 조회 (페이징 적용)
+    @Query("""
+    select fh
+    from FittingHistory fh
+    join fh.userProduct up
+    join up.product p
+    where up.user.userId = :userId
+      and p.productId = :productId
+    order by fh.createdAt desc
+""")
+    List<FittingHistory> findLatestByUserIdAndProductId(
+            @Param("userId") Long userId,
+            @Param("productId") Long productId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/umc/EveryWear/domain/fitting/service/query/FittingQueryService.java
+++ b/src/main/java/com/umc/EveryWear/domain/fitting/service/query/FittingQueryService.java
@@ -9,6 +9,7 @@ import com.umc.EveryWear.domain.user.entity.UserImg;
 import com.umc.EveryWear.domain.user.entity.mapping.UserProduct;
 import com.umc.EveryWear.domain.user.service.query.UserImgQueryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -80,6 +81,23 @@ public class FittingQueryService {
                         up.getProduct().getProductName(),
                         up.getIsLiked()
                 )
+        );
+    }
+
+    // 특정 상품에 대한 가장 최근 피팅 결과 조회
+    public FittingResponseDto.FittingApplyResult getLatestFittingByProduct(Long userId, Long productId) {
+        List<FittingHistory> list =
+                fittingHistoryRepository.findLatestByUserIdAndProductId(userId, productId, PageRequest.of(0, 1));
+
+        if (list.isEmpty()) {
+            throw new FittingException(FittingErrorCode.FITTING_HISTORY_NOT_FOUND);
+        }
+
+        FittingHistory fh = list.get(0);
+
+        return new FittingResponseDto.FittingApplyResult(
+                fh.getFittingId(),
+                fh.getFittingResultImage()
         );
     }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #107 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.
- productId로 해당 상품에 대한 가장 최근 피팅 내역을 가져오는 기능을 추가했습니다.

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!
<img width="2121" height="1002" alt="image" src="https://github.com/user-attachments/assets/11935635-f468-4644-9e30-9638f8208269" />

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.