### PR TITLE
[Refactor] 상품 크롤링 백그라운드 처리

### DIFF
--- a/src/main/java/com/umc/EveryWear/domain/closet/service/query/ClosetQueryService.java
+++ b/src/main/java/com/umc/EveryWear/domain/closet/service/query/ClosetQueryService.java
@@ -14,8 +14,5 @@ public interface ClosetQueryService {
 
     ClosetResDTO.ProductListResponse getClosetDressProducts(Long userId);
 
-    /**
-     * 내 옷장 기타 상품 조회 (is_liked = true, category = "기타", update_at 내림차순)
-     */
     ClosetResDTO.ProductListResponse getClosetEtcProducts(Long userId);
 }

--- a/src/main/java/com/umc/EveryWear/domain/product/dto/res/ProductResDTO.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/dto/res/ProductResDTO.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.umc.EveryWear.domain.product.enums.ShoppingMall;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 public class ProductResDTO {
 

--- a/src/main/java/com/umc/EveryWear/domain/product/entity/Product.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/entity/Product.java
@@ -45,7 +45,7 @@ public class Product extends BaseEntity {
     @Column(name = "AI_review", columnDefinition = "TEXT")
     private String aiReview;
 
-    @Column(name = "product_num")
+    @Column(name = "product_num", unique = true)
     private Long productNum;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
@@ -72,7 +72,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
         return ProductResDTO.ImportResult.builder().dto(result).mall(mall).build();
     }
 
-    // 쇼핑몰 공통 import: URL 검증-기존 상품 처리-크롤링-신규 저장을 단계별 메서드로 위임
+    // 쇼핑몰 공통 import: URL 검증-기존 상품 처리-크롤링-신규 저장 (동기용, 기존 URL 있을 때만 사용하지 않고 직접 import 시 사용)
     private ProductResDTO.ImportDTO doImportByMall(Long userId, String productUrl, ShoppingMall mall) {
         try {
             User user = userRepository.findById(userId)
@@ -92,7 +92,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                     : null;
 
             if (existingByNum != null) {
-                existingByNum.updateProductUrl(productUrl);
+                existingByNum.updateProductUrl(crawlerData.getProductUrl());
                 Product updated = productRepository.save(existingByNum);
                 return resolveOrLinkUserProduct(userId, user, updated, true);
             }


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #이슈번호

## ✨ 작업 개요
> ai(크롤러) 레포 39번 PR과 함께 머지해야 합니다!
상품 크롤링을 백그라운드에서 돌립니다.
상품 URL 저장을 리다이렉트가 필요한 URL(원클릭 링크, 공유코드 링크 등)이면 리다이렉트 처리하여 저장합니다.
DB에 상품이 중복으로 들어가는 것을 방지하기 위해 unique를 추가합니다.
분명 상품번호로 상품이 중복 저장되지 않게 관리하고 있는데.. 제미나이와 함께 토론해 봐도 뭐가 문제인지 모르겠습니다(절규)
서버 DB에도 unique 제약조건 추가해 두었습니다. product 테이블 product_num 컬럼에 걸어두었고, 규칙이름은 uq_product_product_num으로 설정해 두었습니다.

## 📷 이미지 첨부 (선택)
<img width="1587" height="808" alt="image" src="https://github.com/user-attachments/assets/b81047be-8347-43b6-b56a-f5eaa3600f12" />

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.