### PR TITLE
[Fix] refresh토큰을 파라미터로 access토큰 발급 추가

### DIFF
--- a/src/main/java/com/umc/EveryWear/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/EveryWear/domain/auth/controller/AuthController.java
@@ -28,6 +28,18 @@ public class AuthController {
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, result);
     }
 
+    @Operation(summary = "AccessToken 재발급 (스웨거 테스트용)", description = "리프레시 토큰을 직접 파라미터로 넣어 엑세스 토큰을 재발급받습니다.")
+    @PostMapping("/refresh/test")
+    public ApiResponse<TokenRefreshResponse> refreshTest(
+            @RequestParam("refreshToken") String refreshToken,
+            HttpServletResponse response
+    ) {
+        // 공통 로직 호출
+        TokenRefreshResponse result = authService.processRefresh(refreshToken, response);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, result);
+    }
+
+
     @Operation(summary = "로그아웃", description = "사용자를 로그아웃하고 RefreshToken을 무효화합니다.")
     @PostMapping("/logout")
     public ApiResponse<String> logout(

--- a/src/main/java/com/umc/EveryWear/domain/auth/service/AuthService.java
+++ b/src/main/java/com/umc/EveryWear/domain/auth/service/AuthService.java
@@ -39,11 +39,10 @@ public class AuthService {
     private String kakaoAdminKey;
 
     /**
-     * refreshToken(쿠키) -> 검증 -> accessToken 재발급
-     * + refreshToken도 회전(rotate)해서 DB/쿠키 업데이트 (권장)
+     * [공통 로직] refreshToken 문자열을 받아 검증 후 새 토큰들 발급
      */
     @Transactional
-    public TokenRefreshResponse refresh(String refreshToken, HttpServletResponse response) {
+    public TokenRefreshResponse processRefresh(String refreshToken, HttpServletResponse response) {
         if (refreshToken == null || refreshToken.isBlank()) {
             throw new IllegalArgumentException("Refresh token is missing.");
         }
@@ -56,26 +55,33 @@ public class AuthService {
         // 2) 토큰에서 userId 추출
         Long userId = jwtUtil.getUserIdFromToken(refreshToken);
 
-        // 3) DB 조회 + 저장된 refreshToken과 일치하는지 확인 (중요!)
+        // 3) DB 조회 + 저장된 refreshToken과 일치하는지 확인
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found."));
 
         if (user.getRefreshToken() == null || !user.getRefreshToken().equals(refreshToken)) {
-            // 탈취/재사용 방어
             throw new IllegalArgumentException("Refresh token does not match.");
         }
 
         // 4) 새 토큰 발급
         String newAccessToken = jwtUtil.generateAccessToken(user);
-
-        // (권장) refresh token 회전
         String newRefreshToken = jwtUtil.generateRefreshToken(user);
-        user.updateRefreshToken(newRefreshToken); // Dirty checking으로 저장
 
-        // 5) refreshToken 쿠키로 내려주기 (HttpOnly)
+        // 5) DB 업데이트
+        user.updateRefreshToken(newRefreshToken);
+
+        // 6) 쿠키 업데이트 (테스트용 API 호출 시에도 브라우저 쿠키를 동기화해줌)
         setRefreshTokenCookie(response, newRefreshToken);
 
         return new TokenRefreshResponse(newAccessToken);
+    }
+
+    /**
+     * 기존 쿠키 방식 (프론트 운영용)
+     */
+    @Transactional
+    public TokenRefreshResponse refresh(String refreshToken, HttpServletResponse response) {
+        return processRefresh(refreshToken, response);
     }
 
     /**

--- a/src/main/java/com/umc/EveryWear/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/EveryWear/global/config/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
                                 "/login/**",
                                 "/auth/**",
                                 "/api/auth/refresh",
+                                "/api/auth/refresh/test",
                                 "/oauth/callback/**"
                                 //"/api/review/crawl"
                         ).permitAll()


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #이슈번호

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.

최종 검사를 위해, 스웨거에서 리프레시를 파라미터로 넣어서 엑세스 토큰 발급할 수 있게 수정하였습니다.
여전히 쿠키를 통한 재발급도 가능합니다

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.