### PR TITLE
[Refactor] 프로필 이미지 목록 조회, 삭제 응답 통일

### DIFF
--- a/src/main/java/com/umc/EveryWear/domain/user/controller/UserImgController.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/controller/UserImgController.java
@@ -97,10 +97,12 @@ public class UserImgController {
             description = "사용자의 모든 프로필사진들을 조회합니다."
     )
     @GetMapping
-    public List<UserImgResponseDto.UserImgQuery> getProfileImages(
+    public ApiResponse<List<UserImgResponseDto.UserImgQuery>> getProfileImages(
             @AuthenticationPrincipal Long userId
     ) {
-        return userImgQueryService.getProfileImages(userId);
+        return ApiResponse.onSuccess(
+                UserImgSuccessCode.USER_IMG_LIST_FETCHED,
+                userImgQueryService.getProfileImages(userId));
     }
 
     /**
@@ -111,10 +113,11 @@ public class UserImgController {
             description = "사용자가 선택한 프로필사진을 삭제합니다."
     )
     @DeleteMapping("/{imageId}")
-    public void deleteProfileImage(
+    public ApiResponse<Void> deleteProfileImage(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long imageId
     ) {
         userImgCommandService.deleteProfileImage(userId, imageId);
+        return ApiResponse.onSuccess(UserImgSuccessCode.USER_IMG_DELETED, null);
     }
 }

--- a/src/main/java/com/umc/EveryWear/domain/user/exception/code/UserImgSuccessCode.java
+++ b/src/main/java/com/umc/EveryWear/domain/user/exception/code/UserImgSuccessCode.java
@@ -18,10 +18,21 @@ public enum UserImgSuccessCode implements BaseSuccessCode {
             HttpStatus.OK,
             "USERIMG200_1",
             "대표사진이 성공적으로 변경되었습니다."),
+
     REPRESENTIVE_IMG_200(
             HttpStatus.OK,
             "REPRESENTIVE_IMG_200",
-            "사용자의 대표사진 조회에 성공합니다.")
+            "사용자의 대표사진 조회에 성공합니다."),
+
+    USER_IMG_DELETED(
+            HttpStatus.OK,
+            "USERIMG200_2",
+            "사용자 이미지가 성공적으로 삭제되었습니다."),
+
+    USER_IMG_LIST_FETCHED(
+            HttpStatus.OK,
+            "USERIMG200_3",
+            "사용자 이미지 목록이 성공적으로 조회되었습니다.")
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #121 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.
- 프로필 이미지 목록 조회 및 삭제 메서드의 응답을 통일했습니다.

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.