### PR TITLE
[Refactor] 상품 등록 서버 부하 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,18 @@
 EveryWear Backend는 외부 쇼핑몰 상품을 연동 및 관리하고, AI 가상 피팅과 리뷰 분석을 위한 데이터를 제공하는 **Spring Boot 기반 REST API 서버**입니다.
 
 ## 👥 Team
----
 | BE(팀장) | BE | BE | BE |
 | :---: | :---: | :---: | :---: |
 | <img src="https://github.com/junjunseo.png" width="150" height="150"/> | <img src="https://github.com/2ivii.png" width="150" height="150"/> | <img src="https://github.com/whiteys1.png" width="150" height="150"/> | <img src="https://github.com/taerimiiii.png" width="150" height="150"/> |
 | 임준서<br/><a href="https://github.com/junjunseo">@junjunseo</a> | 윤정민<br/><a href="https://github.com/2ivii">@2ivii</a> | 신영섭<br/><a href="https://github.com/whiteys1">@whiteys</a> | 김태림<br/><a href="https://github.com/taerimiiii">@taerimiiii</a> |
 
 ## 💻 Tech Stack
----
 - **Framework/Language**: Spring Boot 3.x, Java 21
 - **Build/Database**: Gradle, MySQL, Spring Data JPA
 - **AI & Security**: Gemini API (Gemini 2.5 Flash, gemini-3-pro-preview, gemini-3-pro-image-preview), OpenAI API (GPT-4o), JWT 기반 소셜 로그인
 - **Docs**: Swagger (SpringDoc)
 
 ## **📂 Project Structure**
----
 도메인형 (Domain-driven)
 ```
 everywear-backend/
@@ -58,12 +55,10 @@ everywear-backend/
 ```
 
 ## **🛠️ Architecture**
----
 <img width="1005" height="541" alt="스크린샷 2026-02-12 오후 7 13 10" src="https://github.com/user-attachments/assets/37592b38-da0f-4187-9cc1-c7bd93f18fc6" />
 
 
 ## **📝 Commit Convention**
----
 | type | 의미 | 예시 |
 | --- | --- | --- |
 | ✨ **feat** | 새로운 기능 | 로그인 API 구현 |

--- a/src/main/java/com/umc/EveryWear/domain/product/converter/ProductConverter.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/converter/ProductConverter.java
@@ -6,22 +6,6 @@ import com.umc.EveryWear.domain.user.entity.mapping.UserProduct;
 
 public class ProductConverter {
 
-    public static ProductResDTO.ImportDTO toImportDTO(Product product) {
-        return toImportDTO(product, false);
-    }
-
-    public static ProductResDTO.ImportDTO toImportDTO(Product product, boolean isUpdated) {
-        return toImportDTO(product, isUpdated, false);
-    }
-
-    public static ProductResDTO.ImportDTO toImportDTO(Product product, boolean isUpdated, boolean isUrlUpdated) {
-        return buildImportDTO(product, false, isUpdated, isUrlUpdated);
-    }
-
-    public static ProductResDTO.ImportDTO toImportDTO(UserProduct userProduct) {
-        return toImportDTO(userProduct, false, false);
-    }
-
     public static ProductResDTO.ImportDTO toImportDTO(UserProduct userProduct, boolean isUpdated, boolean isUrlUpdated) {
         return buildImportDTO(userProduct.getProduct(), userProduct.getIsLiked(), isUpdated, isUrlUpdated);
     }

--- a/src/main/java/com/umc/EveryWear/domain/product/dto/req/ProductReqDTO.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/dto/req/ProductReqDTO.java
@@ -1,6 +1,5 @@
 package com.umc.EveryWear.domain.product.dto.req;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;

--- a/src/main/java/com/umc/EveryWear/domain/product/dto/res/ProductResDTO.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/dto/res/ProductResDTO.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.umc.EveryWear.domain.product.enums.ShoppingMall;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 public class ProductResDTO {
 

--- a/src/main/java/com/umc/EveryWear/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/repository/ProductRepository.java
@@ -7,29 +7,16 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
-    // 전역 상품 조회 (user_id 무관)
-    // 상품 등록 여부판단에 사용
-    Optional<Product> findByProductUrl(String productUrl);
+
     Optional<Product> findByProductNum(Long productNum);
-    Optional<Product> findByProductName(String productName);
 
-    // updatedAt 내림차순으로 모든 상품 조회
-    List<Product> findAllByOrderByUpdatedAtDesc();
-
-    // updatedAt을 현재 시간으로 업데이트
     @Modifying
     @Query("UPDATE Product p SET p.updatedAt = CURRENT_TIMESTAMP WHERE p.productId = :productId")
     void updateUpdatedAt(@Param("productId") Long productId);
-
-    // 상품 URL과 updatedAt을 업데이트
-    @Modifying
-    @Query("UPDATE Product p SET p.productUrl = :productUrl, p.updatedAt = CURRENT_TIMESTAMP WHERE p.productId = :productId")
-    void updateProductUrlAndUpdatedAt(@Param("productId") Long productId, @Param("productUrl") String productUrl);
 
     // AI 리뷰 업데이트
     @Modifying

--- a/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
@@ -110,7 +110,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                 Product existingByNum = productRepository.findByProductNum(productNum).orElse(null);
                 if (existingByNum != null) {
                     // DB에 있으면 크롤링 없이 user_product에만 연결
-                    return resolveOrLinkUserProduct(userId, user, existingByNum, true);
+                    return resolveOrLinkUserProduct(userId, user, existingByNum);
                 }
             }
 
@@ -167,18 +167,18 @@ public class ProductCommandServiceImpl implements ProductCommandService {
         Product existing = productRepository.findByProductNum(productNum)
                 .orElseThrow(() -> new ProductException(ProductErrorCode.CRAWLING_FAILED));
         productRepository.updateUpdatedAt(existing.getProductId());
-        return resolveOrLinkUserProduct(userId, user, existing, true);
+        return resolveOrLinkUserProduct(userId, user, existing);
     }
 
     // 기존 Product에 대한 UserProduct 연결 또는 updatedAt 갱신 후 ImportDTO 반환 (PRODUCT202용)
-    private ProductResDTO.ImportDTO resolveOrLinkUserProduct(Long userId, User user, Product product, boolean isUpdated) {
+    private ProductResDTO.ImportDTO resolveOrLinkUserProduct(Long userId, User user, Product product) {
         UserProduct up = userProductRepository.findByUser_UserIdAndProduct_ProductId(userId, product.getProductId()).orElse(null);
         if (up == null) {
             UserProduct saved = userProductRepository.save(UserProduct.builder().user(user).product(product).build());
-            return ProductConverter.toImportDTO(saved, isUpdated, false);
+            return ProductConverter.toImportDTO(saved, true, false);
         }
         userProductRepository.updateUpdatedAt(userId, product.getProductId(), LocalDateTime.now());
-        return ProductConverter.toImportDTO(up, isUpdated, false);
+        return ProductConverter.toImportDTO(up, true, false);
     }
 
     // 크롤링 데이터로 Product와 UserProduct 생성 후 ImportDTO 반환 (PRODUCT201용)
@@ -268,19 +268,19 @@ public class ProductCommandServiceImpl implements ProductCommandService {
         ProductCrawlingData data = new ProductCrawlingData();
         data.setShoppingmallName(jsonNode.has("shoppingmall_name") ? jsonNode.get("shoppingmall_name").asText() : defaultMallName);
         data.setProductUrl(jsonNode.has("product_url") ? jsonNode.get("product_url").asText() : requestUrl);
-        data.setCategory(getTextOr(jsonNode, "category", "-"));
-        data.setProductImgUrl(getTextOr(jsonNode, "product_img_url", "-"));
-        data.setProductName(getTextOr(jsonNode, "product_name", "-"));
-        data.setBrandName(getTextOr(jsonNode, "brand_name", "-"));
-        data.setPrice(getTextOr(jsonNode, "price", "-"));
+        data.setCategory(getTextOr(jsonNode, "category"));
+        data.setProductImgUrl(getTextOr(jsonNode, "product_img_url"));
+        data.setProductName(getTextOr(jsonNode, "product_name"));
+        data.setBrandName(getTextOr(jsonNode, "brand_name"));
+        data.setPrice(getTextOr(jsonNode, "price"));
         data.setStarPoint(parseStarPoint(jsonNode));
         data.setAiReview(jsonNode.has("AI_review") && !jsonNode.get("AI_review").isNull() ? jsonNode.get("AI_review").asText() : null);
         data.setProductNum(parseProductNum(jsonNode));
         return data;
     }
 
-    private static String getTextOr(JsonNode node, String key, String defaultValue) {
-        return node.has(key) ? node.get(key).asText() : defaultValue;
+    private static String getTextOr(JsonNode node, String key) {
+        return node.has(key) ? node.get(key).asText() : "-";
     }
 
     private static Float parseStarPoint(JsonNode jsonNode) {

--- a/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductCommandServiceImpl.java
@@ -26,6 +26,7 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.dao.DataIntegrityViolationException;
+import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 
@@ -33,6 +34,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Semaphore;
 
 @Slf4j
 @Service
@@ -51,6 +53,16 @@ public class ProductCommandServiceImpl implements ProductCommandService {
 
     @Value("${FASTAPI_BASE_URL}")
     private String fastApiBaseUrl;
+
+    @Value("${product.import.max-concurrent-crawls:3}")
+    private int maxConcurrentCrawls;
+
+    private Semaphore crawlSemaphore;
+
+    @PostConstruct
+    void initCrawlSemaphore() {
+        this.crawlSemaphore = new Semaphore(Math.max(1, maxConcurrentCrawls));
+    }
 
     private static final int CRAWL_TIMEOUT_SECONDS = 120;
 
@@ -103,21 +115,31 @@ public class ProductCommandServiceImpl implements ProductCommandService {
             }
 
             // 4. DB에 없으면 크롤링 후 상품 저장 및 user_product 연결
-            ProductCrawlingData crawlerData = crawlProduct(productUrl, mall);
-            String canonicalUrl = ProductUrlUtil.canonicalizeProductUrl(crawlerData.getProductUrl(), mall);
-            crawlerData.setProductUrl(canonicalUrl);
             try {
-                return createProductAndLink(user, crawlerData);
-            } catch (DataIntegrityViolationException e) {
-                // product_num 중복(동시 등록 등)
-                if (isDuplicateProductNumConstraint(e)) {
-                    // 직전 flush에서 실패한 엔티티들이 다시 flush되지 않도록 영속성 컨텍스트 초기화
-                    if (entityManager != null) {
-                        entityManager.clear();
+                crawlSemaphore.acquire();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("상품 import 대기 중 인터럽트: {}", e.getMessage());
+                throw new ProductException(ProductErrorCode.CRAWLING_FAILED);
+            }
+            try {
+                ProductCrawlingData crawlerData = crawlProduct(productUrl, mall);
+                String canonicalUrl = ProductUrlUtil.canonicalizeProductUrl(crawlerData.getProductUrl(), mall);
+                crawlerData.setProductUrl(canonicalUrl);
+                try {
+                    return createProductAndLink(user, crawlerData);
+                } catch (DataIntegrityViolationException e) {
+                    // product_num 중복(동시 등록 등)
+                    if (isDuplicateProductNumConstraint(e)) {
+                        if (entityManager != null) {
+                            entityManager.clear();
+                        }
+                        return handleDuplicateProductNum(userId, user, crawlerData.getProductNum());
                     }
-                    return handleDuplicateProductNum(userId, user, crawlerData.getProductNum());
+                    throw e;
                 }
-                throw e;
+            } finally {
+                crawlSemaphore.release();
             }
         } catch (ProductException e) {
             throw e;
@@ -215,7 +237,7 @@ public class ProductCommandServiceImpl implements ProductCommandService {
                 .is_liked(saved.getIsLiked())
                 .build();
     }
-  
+
     // 쇼핑몰별 크롤링 공통 호출
     private ProductCrawlingData crawlProduct(String url, ShoppingMall mall) {
         try {

--- a/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductUrlUtil.java
+++ b/src/main/java/com/umc/EveryWear/domain/product/service/command/ProductUrlUtil.java
@@ -19,11 +19,10 @@ public class ProductUrlUtil {
     // 요청 URL을 리다이렉트한 최종 URL로 변환한다.
     // 리다이렉트가 없거나 실패하면 원본 URL을 그대로 반환한다.
     public static String resolveRedirect(String url) {
-        try {
-            HttpClient client = HttpClient.newBuilder()
-                    .followRedirects(HttpClient.Redirect.ALWAYS)
-                    .connectTimeout(Duration.ofSeconds(REDIRECT_RESOLVE_TIMEOUT_SECONDS))
-                    .build();
+        try (HttpClient client = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.ALWAYS)
+                .connectTimeout(Duration.ofSeconds(REDIRECT_RESOLVE_TIMEOUT_SECONDS))
+                .build()) {
 
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
@@ -128,7 +127,7 @@ public class ProductUrlUtil {
                 }
             }
         } catch (Exception e) {
-            log.warn("상품 URL 정규화 실패 (mall: {}, url: {}): {}", mall != null ? mall.name() : "null", url, e.getMessage());
+            log.warn("상품 URL 정규화 실패 (mall: {}, url: {}): {}", mall.name(), url, e.getMessage());
         }
 
         // 패턴에 맞지 않으면 원본 URL 유지

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -63,6 +63,10 @@ kakao:
 fastapi:
   base-url: ${FASTAPI_BASE_URL}
 
+product:
+  import:
+    max-concurrent-crawls: 3
+
 openai:
   api-key: ${OPENAI_API_KEY}
   model: gpt-4o-mini

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,6 +77,10 @@ kakao:
 fastapi:
   base-url: ${FASTAPI_BASE_URL}
 
+product:
+  import:
+    max-concurrent-crawls: 3
+
 openai:
   api-key: ${OPENAI_API_KEY}
   model: gpt-4o-mini


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #125 

## ✨ 작업 개요
> 상품 등록 API의 서버 부하를 (미약하게) 개선하였습니다. 우선 호출된 등록 API를 최대 3개까지 우선 처리하고, 나머지 요청은 세마포어에서 대기했다가 순서대로 크롤링 구간에 들어갑니다.
경고가 뜨는 코드를 수정했습니다.
사용하지 않는 import문을 제거했습니다.
사용하지 않는 오버로딩/오버라이딩 함수들을 삭제했습니다.

## 📷 이미지 첨부 (선택)
무신사, 29cm, W컨셉, 지그재그에서 원클릭URL / 공유URL / 웹URL 상품 등록 API 실행 확인하였습니다.
<img width="1577" height="731" alt="image" src="https://github.com/user-attachments/assets/96ce7430-a4a0-4282-9553-0bc5e6cb4e5c" />
<img width="1578" height="725" alt="image" src="https://github.com/user-attachments/assets/0e8c5e50-ce97-4d2a-b1fd-a88a9f3a2cde" />
<img width="1567" height="730" alt="image" src="https://github.com/user-attachments/assets/8c078e57-e6dc-42f9-8cb1-43c35054cd0f" />
<img width="1582" height="747" alt="image" src="https://github.com/user-attachments/assets/ba58dcdb-7c00-4899-8522-ec131c9e09f4" />

조회 API 실행 확인했습니다.
<img width="1586" height="800" alt="image" src="https://github.com/user-attachments/assets/5311876b-158f-42c9-9f14-d7776d31ad46" />


## 🧐 집중 리뷰 요청
> 
yml 파일에 변수 추가하였습니다.
<img width="386" height="82" alt="image" src="https://github.com/user-attachments/assets/cdf5de58-2e5d-4fdd-8f8e-cf614d145914" />